### PR TITLE
Create the GitHub Page

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -30,6 +30,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: my own build
+        run: |
+          echo "hello world" > text.txt
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: my own build
+      - name: slang-wasm build
         run: |
           ./slang-wasm-build.sh
       - name: Build with Jekyll

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/configure-pages@v5
       - name: my own build
         run: |
-          echo "hello world" > text.txt
+          ./slang-wasm-build.sh
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:

--- a/slang-wasm-build.sh
+++ b/slang-wasm-build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+sudo apt-get install -y ninja-build
+
+mkdir ./slang-repo
+pushd ./slang-repo
+
+git clone https://github.com/emscripten-core/emsdk.git
+
+pushd emsdk
+
+./emsdk install latest
+./emsdk activate latest
+source ./emsdk_env.sh
+
+popd
+
+
+git clone --recursive https://github.com/shader-slang/slang.git
+pushd slang
+
+cmake --workflow --preset generators --fresh
+mkdir generators
+cmake --install build --prefix generators --component generators
+
+emcmake cmake -DSLANG_GENERATORS_PATH=generators/bin --preset emscripten -G "Ninja"
+cmake --build --preset emscripten --target slang-wasm
+
+popd
+
+
+popd
+
+cp slang-repo/slang/build.em/Release/bin/* ./
+
+sudo rm -r slang-repo

--- a/try-slang.js
+++ b/try-slang.js
@@ -51,6 +51,11 @@ void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
 async function webgpuInit()
 {
     const adapter = await navigator.gpu?.requestAdapter();
+    if (!adapter)
+    {
+        console.log('need a browser that supports WebGPU');
+        return;
+    }
 
     const requiredFeatures = [];
 


### PR DESCRIPTION
This PR create the GitHub Page by introducing a page build workflow.
Currently, we don't have slang-wasm in the slang release pacakge, so we have to clone slang repo and build for it.
Once we have the pre-build slang-wasm in the release package, we can remove it from the build workflow.