### PR TITLE
Update the logic of 'Run'

### DIFF
--- a/build.mk
+++ b/build.mk
@@ -18,7 +18,7 @@ COPY:=
 ifeq ($(OS_NAME),Windows)
 	COPY = copy /b /y
 else
-	COPY = cp
+	COPY = cp -rf
 endif
 
 # Helper to ensure a directory exists
@@ -44,6 +44,9 @@ website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/util.js
 website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/pass_through.js
 website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/compute.js
 website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/water_demo.js
+website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/ui.js
+website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/styles
+website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/compiler.js
 
 .PHONY: $(TRY_SLANG_SLANG_SOURCE_DIRECTORY_PATH)/build.em/Release/bin/slang-wasm.js
 $(TRY_SLANG_SLANG_SOURCE_DIRECTORY_PATH)/build.em/Release/bin/slang-wasm.js $(TRY_SLANG_SLANG_SOURCE_DIRECTORY_PATH)/build.em/Release/bin/slang-wasm.wasm &:
@@ -78,3 +81,11 @@ $(TRY_SLANG_TARGET_DIRECTORY_PATH)/compute.js: $(TRY_SLANG_SOURCE_DIRECTORY_PATH
 $(TRY_SLANG_TARGET_DIRECTORY_PATH)/water_demo.js: $(TRY_SLANG_SOURCE_DIRECTORY_PATH)/water_demo.js
 	$(COPY) $^ $@
 
+$(TRY_SLANG_TARGET_DIRECTORY_PATH)/ui.js: $(TRY_SLANG_SOURCE_DIRECTORY_PATH)/ui.js
+	$(COPY) $^ $@
+
+$(TRY_SLANG_TARGET_DIRECTORY_PATH)/styles: $(TRY_SLANG_SOURCE_DIRECTORY_PATH)/styles
+	$(COPY) $^ $@
+
+$(TRY_SLANG_TARGET_DIRECTORY_PATH)/compiler.js: $(TRY_SLANG_SOURCE_DIRECTORY_PATH)/compiler.js
+	$(COPY) $^ $@

--- a/compiler.js
+++ b/compiler.js
@@ -1,0 +1,150 @@
+
+class SlangCompiler
+{
+    static SLANG_STAGE_VERTEX = 1;
+    static SLANG_STAGE_FRAGMENT = 5;
+    static SLANG_STAGE_COMPUTE = 6;
+
+    globalSlangSession = null;
+    slangSession = null;
+
+    slangWasmModule;
+
+    diagnosticsMsg;
+    constructor(module)
+    {
+        this.slangWasmModule = module;
+        this.diagnosticsMsg = "";
+    }
+
+    init()
+    {
+        try {
+            this.globalSlangSession = this.slangWasmModule.createGlobalSession();
+            if(!this.globalSlangSession)
+            {
+                var error = Slang.getLastError();
+                return {ret: false, msg: (error.type + " error: " + error.message)};
+            }
+            else
+            {
+                return {ret: true, msg: ""};
+            }
+        } catch (e) {
+            console.log(e);
+            return {ret: false, msg: '' + e};
+        }
+    }
+
+    // In our playground, we only allow to run shaders with two entry points: renderMain and printMain
+    findRunnableEntryPoint(module)
+    {
+        const runnableEntryPointNames = ['imageMain', 'printMain'];
+        for (var i = 0; i < runnableEntryPointNames.length; i++)
+        {
+            var entryPointName = runnableEntryPointNames[i];
+            var entryPoint = module.findAndCheckEntryPoint(entryPointName, SlangCompiler.SLANG_STAGE_COMPUTE);
+            if(entryPoint)
+            {
+                return entryPoint;
+            }
+            else
+            {
+                var error = this.slangWasmModule.getLastError();
+                console.error(error.type + " error: " + error.message);
+                this.diagnosticsMsg+=(error.type + " error: " + error.message);
+            }
+        }
+
+        return null;
+    }
+
+    findEntryPoint(module, entryPointName, stage)
+    {
+        if (entryPointName == null || entryPointName == "")
+        {
+            var entryPoint = this.findRunnableEntryPoint(module);
+            if (!entryPoint)
+            {
+                this.diagnosticsMsg += "Warning: Only entrypoint with name 'imageMain' or 'printMain' is runnable, ";
+                this.diagnosticsMsg += "please correct the entrypoint name and run it.\n";
+                this.diagnosticsMsg += "Otherwise specify the entrypoint name in 'Compile Option' and only compile it\n";
+            }
+            return entryPoint;
+        }
+        else
+        {
+            var entryPoint = module.findAndCheckEntryPoint(entryPointName, stage);
+            if(!entryPoint) {
+                var error = this.slangWasmModule.getLastError();
+                console.error(error.type + " error: " + error.message);
+                this.diagnosticsMsg += (error.type + " error: " + error.message);
+                return null;
+            }
+        }
+    }
+
+    compile(shaderSource, entryPointName, stage)
+    {
+        try {
+            var slangSession = this.globalSlangSession.createSession();
+            if(!slangSession) {
+                var error = this.slangWasmModule.getLastError();
+                console.error(error.type + " error: " + error.message);
+                this.diagnosticsMsg += (error.type + " error: " + error.message);
+                return null;
+            }
+
+            var module = slangSession.loadModuleFromSource(shaderSource);
+            if(!module) {
+                var error = this.slangWasmModule.getLastError();
+                console.error(error.type + " error: " + error.message);
+                this.diagnosticsMsg+=(error.type + " error: " + error.message);
+                return null;
+            }
+
+            // If no entrypoint is specified, try to find a runnable entry point
+            var entryPoint = this.findEntryPoint(module, entryPointName, stage);
+            if(!entryPoint) {
+                return null;
+            }
+
+            var components = new this.slangWasmModule.ComponentTypeList();
+            components.push_back(module);
+            components.push_back(entryPoint);
+            var program = slangSession.createCompositeComponentType(components);
+            var linkedProgram = program.link();
+            var wgslCode =
+                linkedProgram.getEntryPointCode(
+                    0 /* entryPointIndex */, 0 /* targetIndex */
+                );
+            if(wgslCode == "") {
+                var error = this.slangWasmModule.getLastError();
+                console.error(error.type + " error: " + error.message);
+                this.diagnosticsMsg += (error.type + " error: " + error.message);
+                return null;
+            }
+        } catch (e) {
+            console.log(e);
+            return null;
+        }
+        finally {
+            if(linkedProgram) {
+                linkedProgram.delete();
+            }
+            if(program) {
+                program.delete();
+            }
+            if(entryPoint) {
+                entryPoint.delete();
+            }
+            if(module) {
+                module.delete();
+            }
+            if (slangSession) {
+                slangSession.delete();
+            }
+            return wgslCode;
+        }
+    }
+};

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
     <script src="water_demo.js"></script>
     <script src="pass_through.js"></script>
     <script src="compute.js"></script>
+    <script src="compiler.js"></script>
     <script src="try-slang.js"></script>
     <script src="slang-wasm.js"></script>
   </head>
@@ -73,7 +74,7 @@
             <button id="run-btn" onclick="onRun()" disabled>Run</button>
           </div>
           <div class="navbar-compile navbar-item">
-            <a href="#" class="run-btn">computeMain (Compute) -> SPIRV</a>
+            <a href="#" class="run-btn">computeMain (Compute) -> WGSL</a>
             <button id="compile-btn" onclick="onCompile()" disabled>
               Compile
             </button>


### PR DESCRIPTION
We define the runnable shaders in the playground that only the shader with entrypoint "imageMain" or "printMain" is runnable on the browser.

For other entrypoint name, we won't run it, and will provide the warning message in the diagnostic area. For such case, user will only allowed to:
1. change the entrypoint name to runnable name
2. specify the entrypoint in the compile option dropdown, and only compile it.

Also refactor the code to relocate compile logic to new file compiler.js.

https://kaizhangnv.github.io/slang-playground/