### PR TITLE
Simplify the diagnostic message and fix issues

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -56,14 +56,7 @@ class SlangCompiler
                     this.shaderType = SlangCompiler.RENDER_SHADER;
                 else
                     this.shaderType = SlangCompiler.PRINT_SHADER;
-
                 return entryPoint;
-            }
-            else
-            {
-                var error = this.slangWasmModule.getLastError();
-                console.error(error.type + " error: " + error.message);
-                this.diagnosticsMsg+=(error.type + " error: " + error.message);
             }
         }
 
@@ -92,11 +85,13 @@ class SlangCompiler
                 this.diagnosticsMsg += (error.type + " error: " + error.message);
                 return null;
             }
+            return entryPoint;
         }
     }
 
     compile(shaderSource, entryPointName, stage)
     {
+        this.diagnosticsMsg = "";
         try {
             var slangSession = this.globalSlangSession.createSession();
             if(!slangSession) {


### PR DESCRIPTION
Fix the issue when click the compile button, we should hide the display area first, then go ahead to compile the shader to avoid the causing errors in async render function.