### PR TITLE
Use reflection to populate entrypoint list, fix UI.

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -1,3 +1,7 @@
+function isWholeProgramTarget(compileTarget)
+{
+    return compileTarget == "METAL" || compileTarget == "SPIRV";
+}
 
 class SlangCompiler
 {
@@ -125,6 +129,42 @@ class SlangCompiler
         return disAsmCode;
     }
 
+    findDefinedEntryPoints(shaderSource)
+    {
+        var result = [];
+        try {
+            var slangSession = this.globalSlangSession.createSession(
+                this.compileTargetMap.findCompileTarget("SPIRV"));
+            if(!slangSession) {
+                return [];
+            }
+
+            var module = slangSession.loadModuleFromSource(shaderSource);
+            if(!module) {
+                return [];
+            }
+
+            var count = module.getDefinedEntryPointCount();
+            for (var i = 0; i < count; i++)
+            {
+                var entryPoint = module.getDefinedEntryPoint(i);
+                result.push(entryPoint.getName());
+                entryPoint.delete();
+            }
+        } catch (e) {
+            return [];
+        }
+        finally {
+            if(module) {
+                module.delete();
+            }
+            if (slangSession) {
+                slangSession.delete();
+            }
+        }
+        return result;
+    }
+
     compile(shaderSource, entryPointName, compileTargetStr, stage)
     {
         this.diagnosticsMsg = "";
@@ -152,32 +192,38 @@ class SlangCompiler
                 return null;
             }
 
-            // If no entrypoint is specified, try to find a runnable entry point
-            var entryPoint = this.findEntryPoint(module, entryPointName, stage);
-            if(!entryPoint) {
-                return null;
-            }
-
             var components = new this.slangWasmModule.ComponentTypeList();
             components.push_back(module);
-            components.push_back(entryPoint);
 
+            let isWholeProgram = isWholeProgramTarget(compileTargetStr);
+            if (!isWholeProgram)
+            {
+                // If no entrypoint is specified, try to find a runnable entry point
+                var entryPoint = this.findEntryPoint(module, entryPointName, stage);
+                if(!entryPoint) {
+                    return null;
+                }
+
+                components.push_back(entryPoint);
+            }
             var program = slangSession.createCompositeComponentType(components);
             var linkedProgram = program.link();
 
             var outCode;
             if (compileTargetStr == "SPIRV")
             {
-                const spirvCode = linkedProgram.getEntryPointCodeSpirv(
-                            0 /* entryPointIndex */, 0 /* targetIndex */
+                const spirvCode = linkedProgram.getTargetCodeBlob(
+                            0 /* targetIndex */
                 );
                 outCode = this.spirvDisassembly(spirvCode);
             }
             else
             {
-                outCode = linkedProgram.getEntryPointCode(
-                            0 /* entryPointIndex */, 0 /* targetIndex */
-                );
+                if (isWholeProgram)
+                    outCode = linkedProgram.getTargetCode(0);
+                else
+                    outCode = linkedProgram.getEntryPointCode(
+                        0 /* entryPointIndex */, 0 /* targetIndex */);
             }
 
             if(outCode == "") {
@@ -186,8 +232,6 @@ class SlangCompiler
                 this.diagnosticsMsg += (error.type + " error: " + error.message);
                 return null;
             }
-
-
         } catch (e) {
             console.log(e);
             return null;

--- a/compiler.js
+++ b/compiler.js
@@ -139,7 +139,7 @@ class SlangCompiler
                 return [];
             }
 
-            var module = slangSession.loadModuleFromSource(shaderSource);
+            var module = slangSession.loadModuleFromSource(shaderSource, "user", "/user.slang");
             if(!module) {
                 return [];
             }
@@ -184,7 +184,7 @@ class SlangCompiler
                 return null;
             }
 
-            var module = slangSession.loadModuleFromSource(shaderSource);
+            var module = slangSession.loadModuleFromSource(shaderSource, "user", "/user.slang");
             if(!module) {
                 var error = this.slangWasmModule.getLastError();
                 console.error(error.type + " error: " + error.message);

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
       <img height="80px" src="./static/slang-logo.png" alt="Slang Logo" />
       <div id="loading-status-line">
         <div class="spinner"></div>
-        <p class="loading-status">Loading Playground...</p>
+        <p class="loading-status" id="loadingStatusLabel">Loading Playground...</p>
       </div>
     </div>
     <div id="contentDiv" class="mainContainer" style="display: none;">
@@ -101,20 +101,6 @@
 
           <!-- Entry/Compile section -->
           <div class="navbar-compile navbar-item">
-            <div class="dropdown" id="entrypoint-dropdown">
-              <select
-                class="dropdown-select"
-                id="entrypoint-select"
-                name="entrypoint"
-                aria-label="Entry point"
-              >
-                <option value="" disabled selected>Entry point</option>
-                <option value="imageMain">imageMain</option>
-                <option value="printMain">printMain</option>
-                <option value="computeMain">computeMain</option>
-              </select>
-            </div>
-
             <div class="dropdown" id="target-dropdown">
               <select
                 class="dropdown-select"
@@ -141,6 +127,17 @@
               </select>
             </div>
 
+            <div class="dropdown" id="entrypoint-dropdown">
+              <select
+                class="dropdown-select"
+                id="entrypoint-select"
+                name="entrypoint"
+                aria-label="Entrypoint"
+              >
+                <option value="" disabled selected>Entrypoint</option>
+              </select>
+            </div>
+            
             <button id="compile-btn" onclick="onCompile()" disabled title='Compile the shader to the selected target. Requires the shader to provide a `[shader("stage")]` attribute on the entrypoint function.'>
               Compile
             </button>
@@ -177,7 +174,7 @@
       </div>
       <div class="gutter gutter-horizontal"></div>
       <div class="rightContainer">
-        <div class="resultSpace">
+        <div class="resultSpace" id="resultSplitContainer">
           <div class="outputSpace" id="output">
             <canvas class="renderCanvas" id="canvas"></canvas>
             <textarea

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -152,6 +152,7 @@ button {
   background-color: var(--button-face);
   border-radius: 10px;
   color: white;
+  min-width: max-content;
   transition: background-color 0.2s ease-in-out;
 }
 
@@ -241,7 +242,6 @@ button:disabled:hover {
   flex-direction: column;
   gap: 4px;
   font-size: var(--font-size);
-  min-width:90px;
 }
 
 .input {
@@ -279,7 +279,7 @@ label {
   font-size: 14px;
   cursor: pointer;
   border-radius: 4px;
-  width: 100%;
+  min-width:max-content;
   box-sizing: border-box;
   transition: background-color 0.2s ease-in-out;
 }
@@ -305,7 +305,6 @@ label {
 }
 
 #entrypoint-dropdown {
-  flex: 1 1 0;
   width: auto;
   min-width:max-content;
 }

--- a/test.cpp
+++ b/test.cpp
@@ -40,7 +40,7 @@ void test()
         }
     )";
 
-    slang::wgsl::Module* module1 = session->loadModuleFromSource(source1.c_str());
+    slang::wgsl::Module* module1 = session->loadModuleFromSource(source1.c_str(), "user", "/user.slang");
     if (module1 == nullptr)
     {
         std::cout << "Failed to load module1" << std::endl;
@@ -55,7 +55,7 @@ void test()
     }
 
 
-    slang::wgsl::Module* module2 = session->loadModuleFromSource(source2.c_str());
+    slang::wgsl::Module* module2 = session->loadModuleFromSource(source2.c_str(), "user", "/user.slang");
     if (module2 == nullptr)
     {
         std::cout << "Failed to load module1" << std::endl;

--- a/try-slang.js
+++ b/try-slang.js
@@ -230,6 +230,7 @@ async function render(timeMS)
 
 async function printResult(outputBufferRead)
 {
+    render(0);
     await device.queue.onSubmittedWorkDone();
     // Read the results once the job is done
     await Promise.all([


### PR DESCRIPTION
The "compile" workflow is now streamlined. Most of the time the user just need to click "compile" without going through unnecessary settings.

For SPIRV/Metal that allows multiple entrypoints in a single module, there is not need for the user to select an entrypoint: we can just compile all of them.

This PR makes it auto populate the entrypoint list, and show it only for targets that require it (e.g. GLSL).

Also fixes some canvas resize handling so we never create 0-sized textures that caused webgpu to warn.

Requires new wasm bindings.