### PR TITLE
Add a user module and hide entry point module

### DIFF
--- a/build.mk
+++ b/build.mk
@@ -47,6 +47,7 @@ website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/water_demo.js
 website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/ui.js
 website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/styles
 website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/compiler.js
+website_runtime: $(TRY_SLANG_TARGET_DIRECTORY_PATH)/language-server.js
 
 .PHONY: $(TRY_SLANG_SLANG_SOURCE_DIRECTORY_PATH)/build.em/Release/bin/slang-wasm.js
 $(TRY_SLANG_SLANG_SOURCE_DIRECTORY_PATH)/build.em/Release/bin/slang-wasm.js $(TRY_SLANG_SLANG_SOURCE_DIRECTORY_PATH)/build.em/Release/bin/slang-wasm.wasm &:
@@ -89,4 +90,7 @@ $(TRY_SLANG_TARGET_DIRECTORY_PATH)/styles: $(TRY_SLANG_SOURCE_DIRECTORY_PATH)/st
 	$(COPY) $^ $@
 
 $(TRY_SLANG_TARGET_DIRECTORY_PATH)/compiler.js: $(TRY_SLANG_SOURCE_DIRECTORY_PATH)/compiler.js
+	$(COPY) $^ $@
+
+$(TRY_SLANG_TARGET_DIRECTORY_PATH)/language-server.js: $(TRY_SLANG_SOURCE_DIRECTORY_PATH)/language-server.js
 	$(COPY) $^ $@

--- a/compiler.js
+++ b/compiler.js
@@ -48,12 +48,11 @@ RWStructuredBuffer<int>               outputBuffer;
 
 // TODO: We will fix the threads size
 [shader("compute")]
-[numthreads(16, 16, 1)]
+[numthreads(2, 2, 1)]
 void printMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-
-    int res = printMain(dispatchThreadID.xy, int2(16, 16));
-    int index = dispatchThreadID.y * 16 + dispatchThreadID.x;
+    int res = printMain(dispatchThreadID.xy, int2(2, 2));
+    int index = dispatchThreadID.y * 2 + dispatchThreadID.x;
 
     outputBuffer[index] = res;
 }

--- a/compiler.js
+++ b/compiler.js
@@ -423,12 +423,15 @@ class SlangCompiler
             if(program) {
                 program.delete();
             }
-            if(userModule) {
-                userModule.delete();
+
+            if (components)
+            {
+                for (let i = 0; i < components.size(); i++)
+                {
+                    components.get(i).delete();
+                }
             }
-            // if(playgroundModule) {
-            //     playground.delete();
-            // }
+
             if (slangSession) {
                 slangSession.delete();
             }

--- a/compiler.js
+++ b/compiler.js
@@ -87,8 +87,8 @@ class SlangCompiler
         this.slangWasmModule = module;
         this.diagnosticsMsg = "";
         this.shaderType = SlangCompiler.NON_RUNNABLE_SHADER;
-        this.mainModules['imageMain'] = {source: imageMainSource, module: null, entryPoint: null};
-        this.mainModules['printMain'] = {source: printMainSource, module: null, entryPoint: null};
+        this.mainModules['imageMain'] = {source: imageMainSource};
+        this.mainModules['printMain'] = {source: printMainSource};
         FS.createDataFile("/", "user.slang", "", true, true);
     }
 
@@ -273,13 +273,10 @@ class SlangCompiler
         if (moduleName != "printMain" && moduleName != "imageMain")
             return null;
 
-        if (this.mainModules[moduleName].module)
-            return this.mainModules[moduleName];
-
-        this.mainModules[moduleName] = this.compileEntryPointModule(slangSession, moduleName);
+        let mainModule = this.compileEntryPointModule(slangSession, moduleName);
 
         this.shaderType = SlangCompiler.RENDER_SHADER;
-        return this.mainModules[moduleName];
+        return mainModule;
     }
 
     addActiveEntryPoints(slangSession, shaderSource, entryPointName, isWholeProgram, userModule, componentList)

--- a/compiler.js
+++ b/compiler.js
@@ -3,6 +3,62 @@ function isWholeProgramTarget(compileTarget)
     return compileTarget == "METAL" || compileTarget == "SPIRV";
 }
 
+const imageMainSource = `
+import user;
+
+uniform float time;
+RWStructuredBuffer<int>               outputBuffer;
+[format("r32f")] RWTexture2D<float>   texture;
+
+inline float encodeColor(float4 color)
+{
+    uint4 colorInt = { uint(color.x * 255.0f),
+                       uint(color.y * 255.0f),
+                       uint(color.z * 255.0f),
+                       uint(color.w * 255.0f) };
+
+    float encodedColor = float(colorInt.x << 24 | colorInt.y << 16 | colorInt.z << 8 | colorInt.w);
+    return encodedColor;
+}
+
+[shader("compute")]
+void imageMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint width = 0;
+    uint height = 0;
+    texture.GetDimensions(width, height);
+    float4 color = imageMain(dispatchThreadID.xy, int2(width, height), time);
+    float encodedColor = encodeColor(color);
+
+    texture[dispatchThreadID.xy] = encodedColor;
+}
+`;
+
+// TODO: add any utility functions here
+const playgroundSource = `
+
+`;
+
+const printMainSource = `
+import user;
+
+uniform float time;
+RWStructuredBuffer<int>               outputBuffer;
+[format("r32f")] RWTexture2D<float>   texture;
+
+// TODO: We will fix the threads size
+[shader("compute")]
+[numthreads(16, 16, 1)]
+void printMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+
+    int res = printMain(dispatchThreadID.xy, int2(16, 16));
+    int index = dispatchThreadID.y * 16 + dispatchThreadID.x;
+
+    outputBuffer[index] = res;
+}
+`;
+
 class SlangCompiler
 {
     static SLANG_STAGE_VERTEX = 1;
@@ -24,11 +80,15 @@ class SlangCompiler
 
     spirvToolsModule = null;
 
+    mainModules = new Map();
+
     constructor(module)
     {
         this.slangWasmModule = module;
         this.diagnosticsMsg = "";
         this.shaderType = SlangCompiler.NON_RUNNABLE_SHADER;
+        this.mainModules['imageMain'] = {source: imageMainSource, module: null, entryPoint: null};
+        this.mainModules['printMain'] = {source: printMainSource, module: null, entryPoint: null};
         FS.createDataFile("/", "user.slang", "", true, true);
     }
 
@@ -129,6 +189,10 @@ class SlangCompiler
         return disAsmCode;
     }
 
+    // If user code defines imageMain or printMain, we will know the entry point name because they're
+    // already defined in our pre-built module. So we will add those one of those entry points to the
+    // dropdown list. Then, we will find whether user code also defines other entry points, if it has
+    // we will also add them to the dropdown list.
     findDefinedEntryPoints(shaderSource)
     {
         var result = [];
@@ -139,15 +203,23 @@ class SlangCompiler
                 return [];
             }
 
+            if (shaderSource.match("imageMain"))
+                result.push("imageMain")
+
+            if (shaderSource.match("printMain"))
+                result.push("printMain")
+
             var module = slangSession.loadModuleFromSource(shaderSource, "user", "/user.slang");
             if(!module) {
-                return [];
+                return result;
             }
 
             var count = module.getDefinedEntryPointCount();
             for (var i = 0; i < count; i++)
             {
                 var entryPoint = module.getDefinedEntryPoint(i);
+                const entryPointName = entryPoint.getName();
+
                 result.push(entryPoint.getName());
                 entryPoint.delete();
             }
@@ -165,10 +237,128 @@ class SlangCompiler
         return result;
     }
 
+    // If user entrypoint name imageMain or printMain, we will load the pre-built main modules because they
+    // are defined in those modules. Otherwise, we will only need to load the user module and find the entry
+    // point in the user module.
+    shouldLoadMainModule(entryPointName)
+    {
+        return entryPointName == "imageMain" || entryPointName == "printMain";
+    }
+
+    // Since we will not let user to change the entry point code, we can precompile the entry point module
+    // and reuse it for every compilation.
+
+    compileEntryPointModule(slangSession, moduleName)
+    {
+        var module = slangSession.loadModuleFromSource(this.mainModules[moduleName].source, moduleName, '/' + moduleName + '.slang');
+
+        if (!module) {
+            var error = this.slangWasmModule.getLastError();
+            console.error(error.type + " error: " + error.message);
+            this.diagnosticsMsg+=(error.type + " error: " + error.message);
+            return null;
+        }
+
+        // we use the same entry point name as module name
+        var entryPoint = this.findEntryPoint(module, moduleName, SlangCompiler.SLANG_STAGE_COMPUTE);
+        if (!entryPoint)
+            return null;
+
+        return {module: module, entryPoint: entryPoint};
+
+    }
+
+    getPrecompiledProgram(slangSession, moduleName)
+    {
+        if (moduleName != "printMain" && moduleName != "imageMain")
+            return null;
+
+        if (this.mainModules[moduleName].module)
+            return this.mainModules[moduleName];
+
+        this.mainModules[moduleName] = this.compileEntryPointModule(slangSession, moduleName);
+
+        this.shaderType = SlangCompiler.RENDER_SHADER;
+        return this.mainModules[moduleName];
+    }
+
+    addActiveEntryPoints(slangSession, shaderSource, entryPointName, isWholeProgram, userModule, componentList)
+    {
+        if (entryPointName == "" && !isWholeProgram)
+        {
+            this.diagnosticsMsg+=("error: No entry point specified");
+            return false;
+        }
+
+        // For now, we just don't allow user to define imageMain or printMain as entry point name for simplicity
+        var count = userModule.getDefinedEntryPointCount();
+        for (var i = 0; i < count; i++)
+        {
+            var entryPointName = userModule.getDefinedEntryPoint(i).getName();
+            if (entryPointName == "imageMain" || entryPointName == "printMain")
+            {
+                this.diagnosticsMsg+=("error: Entry point name 'imageMain' or 'printMain' is reserved");
+                return false;
+            }
+        }
+
+        // If entry point is provided, we know for sure this is not a whole program compilation,
+        // so we will just go to find the correct module to include in the compilation.
+        if (entryPointName != "")
+        {
+            if (this.shouldLoadMainModule(entryPointName))
+            {
+                // we use the same entry point name as module name
+                var mainProgram = this.getPrecompiledProgram(slangSession, entryPointName);
+                if (!mainProgram)
+                    return false;
+
+                this.shaderType = entryPointName == "imageMain" ?
+                    SlangCompiler.RENDER_SHADER : SlangCompiler.PRINT_SHADER;
+
+                componentList.push_back(mainProgram.module);
+                componentList.push_back(mainProgram.entryPoint);
+            }
+            else
+            {
+                // we know the entry point is from user module
+                var entryPoint = this.findEntryPoint(userModule, entryPointName, SlangCompiler.SLANG_STAGE_COMPUTE);
+                if (!entryPoint)
+                    return false;
+
+                componentList.push_back(entryPoint);
+            }
+        }
+        // otherwise, it's a whole program compilation, we will find all active entry points in the user code
+        // and pre-built modules.
+        else
+        {
+            const results = this.findDefinedEntryPoints(shaderSource);
+            for (let i = 0; i < results.length; i++)
+            {
+                if (results[i] == "imageMain" || results[i] == "printMain")
+                {
+                    var mainProgram = this.getPrecompiledProgram(slangSession, results[i]);
+                    componentList.push_back(mainProgram.module);
+                    componentList.push_back(mainProgram.entryPoint);
+                }
+                else
+                {
+                    var entryPoint = this.findEntryPoint(userModule, results[i], SlangCompiler.SLANG_STAGE_COMPUTE);
+                    if (!entryPoint)
+                        return false;
+
+                    componentList.push_back(entryPoint);
+                }
+            }
+        }
+    }
+
     compile(shaderSource, entryPointName, compileTargetStr, stage)
     {
         this.diagnosticsMsg = "";
         const compileTarget = this.compileTargetMap.findCompileTarget(compileTargetStr);
+        let isWholeProgram = isWholeProgramTarget(compileTargetStr);
 
         if(!compileTarget) {
             this.diagnosticsMsg = "unknown compile target: " + compileTargetStr;
@@ -184,8 +374,9 @@ class SlangCompiler
                 return null;
             }
 
-            var module = slangSession.loadModuleFromSource(shaderSource, "user", "/user.slang");
-            if(!module) {
+            // Load the user module, this is the source code that user inputs in the editor
+            var userModule = slangSession.loadModuleFromSource(shaderSource, "user", "/user.slang");
+            if(!userModule) {
                 var error = this.slangWasmModule.getLastError();
                 console.error(error.type + " error: " + error.message);
                 this.diagnosticsMsg+=(error.type + " error: " + error.message);
@@ -193,19 +384,11 @@ class SlangCompiler
             }
 
             var components = new this.slangWasmModule.ComponentTypeList();
-            components.push_back(module);
+            components.push_back(userModule);
 
-            let isWholeProgram = isWholeProgramTarget(compileTargetStr);
-            if (!isWholeProgram)
-            {
-                // If no entrypoint is specified, try to find a runnable entry point
-                var entryPoint = this.findEntryPoint(module, entryPointName, stage);
-                if(!entryPoint) {
-                    return null;
-                }
+            if (this.addActiveEntryPoints(slangSession, shaderSource, entryPointName, isWholeProgram, userModule, components) == false)
+                return null;
 
-                components.push_back(entryPoint);
-            }
             var program = slangSession.createCompositeComponentType(components);
             var linkedProgram = program.link();
 
@@ -243,12 +426,12 @@ class SlangCompiler
             if(program) {
                 program.delete();
             }
-            if(entryPoint) {
-                entryPoint.delete();
+            if(userModule) {
+                userModule.delete();
             }
-            if(module) {
-                module.delete();
-            }
+            // if(playgroundModule) {
+            //     playground.delete();
+            // }
             if (slangSession) {
                 slangSession.delete();
             }

--- a/compute.js
+++ b/compute.js
@@ -96,7 +96,7 @@ class ComputePipeline
             let usage = GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC;
 
             // we will fix the size of the workgroup to be 32x32 for printMain.
-            const numberElements = 16 * 16 /*windowSize[0] * windowSize[1]*/;
+            const numberElements = 1;
             const size = numberElements * 4; // int type
             this.outputBuffer = this.device.createBuffer({lable: 'outputBuffer', size, usage});
 

--- a/compute.js
+++ b/compute.js
@@ -94,7 +94,9 @@ class ComputePipeline
         {
             this.destroyResources();
             let usage = GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC;
-            const numberElements = windowSize[0] * windowSize[1];
+
+            // we will fix the size of the workgroup to be 32x32 for printMain.
+            const numberElements = 16 * 16 /*windowSize[0] * windowSize[1]*/;
             const size = numberElements * 4; // int type
             this.outputBuffer = this.device.createBuffer({lable: 'outputBuffer', size, usage});
 

--- a/compute.js
+++ b/compute.js
@@ -95,8 +95,8 @@ class ComputePipeline
             this.destroyResources();
             let usage = GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC;
 
-            // we will fix the size of the workgroup to be 32x32 for printMain.
-            const numberElements = 1;
+            // we will fix the size of the workgroup to be 2 x 2 for printMain.
+            const numberElements = 2 * 2;
             const size = numberElements * 4; // int type
             this.outputBuffer = this.device.createBuffer({lable: 'outputBuffer', size, usage});
 

--- a/try-slang.js
+++ b/try-slang.js
@@ -235,9 +235,7 @@ async function printResult()
 
     await device.queue.onSubmittedWorkDone();
     // Read the results once the job is done
-    await Promise.all([
-        computePipeline.outputBufferRead.mapAsync(GPUMapMode.READ),
-    ]);
+    await computePipeline.outputBufferRead.mapAsync(GPUMapMode.READ);
 
     const output = new Int32Array(computePipeline.outputBufferRead.getMappedRange());
 
@@ -269,11 +267,8 @@ function checkShaderType(userSource)
 
     // Only one of the main function should be defined.
     // In this case, we will know that the shader is not runnable, so we can only compile it.
-    if ( (!isImageMain && !isPrintMain) ||
-         (isImageMain && isPrintMain) )
-    {
+    if (isImageMain == isPrintMain)
         return SlangCompiler.NON_RUNNABLE_SHADER;
-    }
 
     if (isImageMain)
         return SlangCompiler.RENDER_SHADER;

--- a/try-slang.js
+++ b/try-slang.js
@@ -28,7 +28,7 @@ var currentMode = RENDER_MODE;
 // looking at the generated shader code?
 const defaultShaderCode = `
 
-export float4 imageMain(uint2 dispatchThreadID, int2 screenSize, float time)
+float4 imageMain(uint2 dispatchThreadID, int2 screenSize, float time)
 {
     float2 size = float2(screenSize.x, screenSize.y);
     float2 center = size / 2.0;

--- a/ui.js
+++ b/ui.js
@@ -33,6 +33,7 @@ function updateProfileOptions(targetSelect, profileSelect) {
   // If the target can be compiled as a whole program without entrypoint selection, hide the entrypoint dropdown.
   if (isWholeProgramTarget(targetSelect.value)) {
     document.getElementById("entrypoint-dropdown").style.display = "none";
+    document.getElementById("entrypoint-select").value = "";
   } else {
     document.getElementById("entrypoint-dropdown").style = "";
     updateEntryPointOptions();


### PR DESCRIPTION
We will only expose the user module in the website editor, the shader will look like

export float4 imageMain(uint2 dispatchThreadID, int2 screenSize, float time) {...}

export float4 printMain(uint2 dispatchThreadID, int2 screenSize) {...}

And we pre-defined two entry-point modules, one is "imageMain" module with an entry point named "imageMain", the other one is "printMain" module with an entry point named "printMain".

And our new rule will be:
1. If one of these functions are defined in user code, we can run the code by loading our pre-built module.

2. If both of these functions are defined, we can not run the code, but we can compile the code iff the target is SPIRV/METAL

3. If none of these functions are defined in user code, then 
     3.1 if user also defines an entry point, we can still compile it with user's entry point, and we will not load our pre-built modules. 
     3.2 if user also defines more than one entry points, we can still compile it with user's entry points iff the target is SPIRV/METAL. 
     3.3 if user doesn't define an entry point, nothing will be compiled.

4. If user also defined an entry point in case 1 and 2, only when the target is SPIRV/METAL can the code get compiled.

5. User is not allowed to use imageMain or printMain as their entry point name.