### PR TITLE
Ocean demo: Link to original shader

### DIFF
--- a/demos/ocean.slang
+++ b/demos/ocean.slang
@@ -1,3 +1,8 @@
+// "Very fast procedural ocean" by afl_ext, https://www.shadertoy.com/view/MdXyzX, ported to Slang.
+// Copyright (C) 2017-2024 afl_ext
+// Copyright (C) 2024 NVIDIA Corporation
+// SPDX-License-Identifier: MIT
+
 // afl_ext 2017-2024
 // MIT License
 import playground;


### PR DESCRIPTION
We include the license information from the original shader, but I figure it's good form to include the link and list the changes made. For the copyright header, I've chosen to include both the standard format (complete list of authors, SPDX license ID) as well as the original license text in the shader.