### PR TITLE
Fixes typo where the help dialog referred to the wrong example of a print shader

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
           <li><b>Image Compute Shader</b>: This is a compute shader that returns a pixel value at a given image coordinate, similar to ShaderToys.
           An image compute shader must define a imageMain function, see the "Circle" demo for an example.</li>
           <li><b>Print Shader</b>: This is a shader that prints text to the text output window.
-            A print shader must define a printMain function, see the "Ocean" demo for an example.</li>
+            A print shader must define a printMain function, see the "Simple Print" demo for an example.</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
We probably intended to refer to the "Simple Print" demo instead of the "Ocean" demo here.

Thanks!