### PR TITLE
Ocean demo: Calculate exact normals using autodifferentiation

### DIFF
--- a/demos/ocean.slang
+++ b/demos/ocean.slang
@@ -10,6 +10,7 @@ static const int ITERATIONS_NORMAL = 37; // waves iterations when calculating no
 
 // Calculates wave value and its derivative, 
 // for the wave direction, position in space, wave frequency and time
+[BackwardDifferentiable]
 float2 wavedx(float2 position, float2 direction, float frequency, float timeshift) {
   float x = dot(direction, position) * frequency + timeshift;
   float wave = exp(sin(x) - 1.0);
@@ -18,7 +19,8 @@ float2 wavedx(float2 position, float2 direction, float frequency, float timeshif
 }
 
 // Calculates waves by summing octaves of various waves with various parameters
-float getwaves(float2 position, int iterations) {
+[BackwardDifferentiable]
+float getwaves<int iterations>(float2 position) {
   float wavePhaseShift = length(position) * 0.1; // this is to avoid every octave having exactly the same phase everywhere
   float iter = 0.0; // this will help generating well distributed wave directions
   float frequency = 1.0; // frequency of the wave, this will change every iteration
@@ -26,12 +28,13 @@ float getwaves(float2 position, int iterations) {
   float weight = 1.0;// weight in final sum for the wave, this will change every iteration
   float sumOfValues = 0.0; // will store final sum of values
   float sumOfWeights = 0.0; // will store final sum of weights
+  [ForceUnroll]
   for(int i=0; i < iterations; i++) {
     // generate some wave direction that looks kind of random
     float2 p = float2(sin(iter), cos(iter));
     
     // calculate wave data
-    float2 res = wavedx(position, p, frequency, getTime() * timeMultiplier + wavePhaseShift);
+    float2 res = wavedx(position, p, frequency, no_diff getTime() * timeMultiplier + wavePhaseShift);
 
     // shift position around according to wave drag and derivative of the wave
     position += p * res.y * weight * DRAG_MULT;
@@ -58,7 +61,7 @@ float raymarchwater(float3 camera, float3 start, float3 end, float depth) {
   float3 dir = normalize(end - start);
   for(int i=0; i < 64; i++) {
     // the height is from 0 to -depth
-    float height = getwaves(pos.xz, ITERATIONS_RAYMARCH) * depth - depth;
+    float height = getwaves<ITERATIONS_RAYMARCH>(pos.xz) * depth - depth;
     // if the waves height almost nearly matches the ray height, assume its a hit and return the hit distance
     if(height + 0.01 > pos.y) {
       return distance(pos, camera);
@@ -72,16 +75,10 @@ float raymarchwater(float3 camera, float3 start, float3 end, float depth) {
 }
 
 // Calculate normal at point by calculating the height at the pos and 2 additional points very close to pos
-float3 normal(float2 pos, float e, float depth) {
-  float2 ex = float2(e, 0);
-  float H = getwaves(pos.xy, ITERATIONS_NORMAL) * depth;
-  float3 a = float3(pos.x, H, pos.y);
-  return normalize(
-    cross(
-      a - float3(pos.x - e, getwaves(pos.xy - ex.xy, ITERATIONS_NORMAL) * depth, pos.y),
-      a - float3(pos.x, getwaves(pos.xy + ex.yx, ITERATIONS_NORMAL) * depth, pos.y + e)
-    )
-  );
+float3 normal(float2 pos, float depth) {
+  DifferentialPair<float2> diffPos = diffPair(pos);
+  bwd_diff(getwaves<ITERATIONS_NORMAL>)(diffPos, 1.0);
+  return normalize(float3(-diffPos.d.x, 1.0, -diffPos.d.y));
 }
 
 // Helper function generating a rotation matrix around the axis by the angle
@@ -201,7 +198,7 @@ float4 imageMain(uint2 dispatchThreadID, int2 screenSize)
   float3 waterHitPos = origin + ray * dist;
 
   // calculate normal at the hit position
-  float3 N = normal(waterHitPos.xz, 0.01, WATER_DEPTH);
+  float3 N = normal(waterHitPos.xz, WATER_DEPTH);
 
   // smooth the normal with distance to avoid disturbing high frequency noise
   float interpFactor = 0.8 * min(1.0, sqrt(dist*0.01) * 1.1);


### PR DESCRIPTION
This might be a good place to show off how Slang's auto-diff can be used to compute exact normals without having to manually write a function that computes the gradient.

I haven't measured performance of this; while `bwd_diff` is simpler, Yong mentioned that two `fwd_diff` passes should be faster. I'm fine with either one.

Thanks!