### PR TITLE
Support ZEROS on textures including storage textures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 slang-wasm.js
 slang-wasm.wasm
+slang-wasm.wasm.gz

--- a/compiler.js
+++ b/compiler.js
@@ -367,7 +367,7 @@ class SlangCompiler
         }
         else if (bindingType == this.slangWasmModule.BindingType.MutableTexture)
         {
-            return { storageTexture: {access: "read-write", format: "r32float"} };
+            return { storageTexture: {access: "read-write", format: "r32uint"} };
         }
         else if (bindingType == this.slangWasmModule.BindingType.ConstantBuffer)
         {

--- a/compiler.js
+++ b/compiler.js
@@ -367,7 +367,7 @@ class SlangCompiler
         }
         else if (bindingType == this.slangWasmModule.BindingType.MutableTexture)
         {
-            return { storageTexture: {access: "read-write", format: "r32uint"} };
+            return { storageTexture: {access: "read-write", format: "r32float"} };
         }
         else if (bindingType == this.slangWasmModule.BindingType.ConstantBuffer)
         {

--- a/try-slang.js
+++ b/try-slang.js
@@ -432,20 +432,44 @@ async function processResourceCommands(pipeline, resourceBindings, resourceComma
                 throw new Error(`Resource ${resourceName} is not defined in the bindings.`);
             }
 
-            if (!bindingInfo.buffer) {
-                throw new Error(`Resource ${resourceName} is not defined as a buffer.`);
+            if (bindingInfo.buffer) {
+                const buffer = pipeline.device.createBuffer({
+                    size: size * elementSize,
+                    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+                });
+
+                safeSet(allocatedResources, resourceName, buffer);
+
+                // Initialize the buffer with zeros.
+                const zeros = new Float32Array(size);
+                pipeline.device.queue.writeBuffer(buffer, 0, zeros);
+            } else if (bindingInfo.texture || bindingInfo.storageTexture) {
+                if (parsedCommand.size.length !== 2) {
+                    throw new Error(`Invalid parameter count ${parsedCommand.size.length} for ZEROS on texture ${resourceName}, should be 2.`);
+                }
+                try {
+                    let usage = GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT;
+                    if (bindingInfo.storageTexture) {
+                        usage |= GPUTextureUsage.STORAGE_BINDING;
+                    }
+                    const texture = pipeline.device.createTexture({
+                        size: parsedCommand.size,
+                        format: bindingInfo.storageTexture?'r32uint':'rgba8unorm',
+                        usage: usage,
+                    });
+
+                    safeSet(allocatedResources, resourceName, texture);
+
+                    // Initialize the texture with zeros.
+                    let zeros = new Uint8Array(Array(size*elementSize).fill(0));
+                    pipeline.device.queue.writeTexture({ texture }, zeros, {bytesPerRow: parsedCommand.size[0] * elementSize}, { width: parsedCommand.size[0], height: parsedCommand.size[1] });
+                }
+                catch (error) {
+                    throw new Error(`Failed to create texture: ${error}`);
+                }
+            } else {
+                throw new Error(`Resource ${resourceName} is an invalid type for ZEROS`);
             }
-
-            const buffer = pipeline.device.createBuffer({
-                size: size * elementSize,
-                usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-            });
-
-            safeSet(allocatedResources, resourceName, buffer);
-
-            // Initialize the buffer with zeros.
-            const zeros = new Float32Array(size);
-            pipeline.device.queue.writeBuffer(buffer, 0, zeros);
         }
         else if (parsedCommand.type === "URL") {
             // Load image from URL and wait for it to be ready.

--- a/try-slang.js
+++ b/try-slang.js
@@ -454,7 +454,7 @@ async function processResourceCommands(pipeline, resourceBindings, resourceComma
                     }
                     const texture = pipeline.device.createTexture({
                         size: parsedCommand.size,
-                        format: bindingInfo.storageTexture?'r32uint':'rgba8unorm',
+                        format: bindingInfo.storageTexture?'r32float':'rgba8unorm',
                         usage: usage,
                     });
 


### PR DESCRIPTION
This allows the ZEROS preprocessor to be used to initialize textures and makes storage textures usable. Only `uint` storage textures will work since I couldn't find a way to get the type via reflection and it seems slang automatically compiles all `float` storage textures to `rgba32float` format which is incompatible with read-write storage textures.