### PR TITLE
Improve error display and make entry points visible

### DIFF
--- a/compiler.ts
+++ b/compiler.ts
@@ -217,16 +217,16 @@ export class SlangCompiler {
     // dropdown list. Then, we will find whether user code also defines other entry points, if it has
     // we will also add them to the dropdown list.
     findDefinedEntryPoints(shaderSource: string): string[] {
-        var result: string[] = [];
+        let result: string[] = [];
         if (shaderSource.match("imageMain")) {
-            return ["imageMain"];
+            result.push("imageMain");
         }
         if (shaderSource.match("printMain")) {
-            return ["printMain"];
+            result.push("printMain");
         }
-
+        let slangSession: Session | null | undefined;
         try {
-            var slangSession = this.globalSlangSession?.createSession(
+            slangSession = this.globalSlangSession?.createSession(
                 this.findCompileTarget("SPIRV"));
             if (!slangSession) {
                 return [];
@@ -430,7 +430,7 @@ export class SlangCompiler {
     loadModule(slangSession: Session, moduleName: string, source: string, componentTypeList: Module[]) {
         var module: Module | null = slangSession.loadModuleFromSource(source, moduleName, "/" + moduleName + ".slang");
         if (!module) {
-            var error = this.slangWasmModule.getLastError();
+            const error = this.slangWasmModule.getLastError();
             console.error(error.type + " error: " + error.message);
             this.diagnosticsMsg += (error.type + " error: " + error.message);
             return false;

--- a/try-slang.ts
+++ b/try-slang.ts
@@ -77,6 +77,10 @@ export function setEditorValue(editor: monaco.editor.IStandaloneCodeEditor, valu
         editor.revealLine(0);
 }
 
+export function appendEditorValue(editor: monaco.editor.IStandaloneCodeEditor, value: string, revealEnd: boolean = false) {
+    setEditorValue(editor, editor.getValue() + value, revealEnd);
+}
+
 async function webgpuInit() {
     try {
         const adapter = await navigator.gpu?.requestAdapter();
@@ -186,10 +190,10 @@ function withRenderLock(setupFn: { (): Promise<void>; }, renderFn: { (timeMS: nu
                 requestAnimationFrame(newRenderLoop);
             }).catch((error: Error) => {
                 if (error instanceof NotReadyError) {
-                }
-                else {
+                    // do nothing
+                } else {
                     if (diagnosticsArea != null)
-                        setEditorValue(diagnosticsArea, error.message, true);
+                        appendEditorValue(diagnosticsArea, error.message, true);
                 }
                 releaseRenderLock();
             });


### PR DESCRIPTION
This pr does two things:
* It prevents entry point compilation failure from overwriting error messages that are more useful in the diagnostic panel
* It allows selecting other entry points for compilation even when `imageMain` is available. This is useful for me to debug wgsl outputs in certain cases.