### PR TITLE
Validate Resource commands and properly account for element size

### DIFF
--- a/compiler.ts
+++ b/compiler.ts
@@ -73,21 +73,54 @@ type BindingDescriptor = {
 
 export type Bindings = Map<string, GPUBindGroupLayoutEntry>;
 
+export type ReflectionBinding = {
+    "kind": "uniform",
+    "offset": number,
+    "size": number,
+} | {
+    "kind": "descriptorTableSlot",
+    "index": number,
+};
+
+export type ReflectionType = {
+    "kind": "struct",
+    "name": string,
+    "fields": ReflectionParameter[]
+} | {
+    "kind": "vector",
+    "elementCount": number,
+    "elementType": ReflectionType,
+} | {
+    "kind": "scalar",
+    "scalarType": `${"uint" | "int"}${8 | 16 | 32 | 64}` | `${"float"}${16 | 32 | 64}`,
+} | {
+    "kind": "resource",
+    "baseShape": "structuredBuffer",
+    "access"?: "readWrite",
+    "resultType": ReflectionType
+} | {
+    "kind": "resource",
+    "baseShape": "texture2D",
+    "access"?: "readWrite"
+};
+
+export type ReflectionParameter =  {
+    "binding": ReflectionBinding,
+    "name": string,
+    "type": ReflectionType,
+    "userAttribs"?: {
+        "arguments": any[],
+        "name": string,
+    }[],
+}
+
 export type ReflectionJSON = {
     "entryPoints": {
         "name": string,
         "semanticName": string,
         "type": unknown
     }[],
-    "parameters": {
-        "binding": unknown,
-        "name": string,
-        "type": unknown,
-        "userAttribs"?: {
-            "arguments": any[],
-            "name": string,
-        }[],
-    }[],
+    "parameters": ReflectionParameter[],
 };
 
 


### PR DESCRIPTION
I'm marking this as fixes #86 and going to open issues for any other silent failures I find. This fixes a number of issues due to lack of validation and not previously calculating element sizes. It feels like there should be reflection information on image format/inner type, but it doesn't look like there is currently.