### PR TITLE
Make WGSL a whole program target

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -337,6 +337,7 @@ export type Shader = {
     hashedStrings: any,
     reflection: ReflectionJSON,
     threadGroupSize: ThreadGroupSize | { x: number, y: number, z: number },
+    entryPoint: string,
 };
 
 export type MaybeShader = Shader | {
@@ -364,7 +365,7 @@ function compileShader(userSource: string, entryPoint: string, compileTarget: ty
     window.$jsontree.setJson("reflectionDiv", reflectionJson);
     window.$jsontree.refreshAll();
 
-    return { succ: true, code: compiledCode, layout: layout, hashedStrings: hashedStrings, reflection: reflectionJson, threadGroupSize: threadGroupSize };
+    return { succ: true, code: compiledCode, layout: layout, hashedStrings: hashedStrings, reflection: reflectionJson, threadGroupSize: threadGroupSize, entryPoint };
 }
 
 function restoreSelectedTargetFromURL() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@ import Help from './components/Help.vue'
 import RenderCanvas from './components/RenderCanvas.vue'
 import { compiler, checkShaderType, slangd, moduleLoadingMessage } from './try-slang'
 import { defineAsyncComponent, onBeforeMount, onMounted, ref, useTemplateRef, type Ref } from 'vue'
-import { isWholeProgramTarget, type Bindings, type ReflectionJSON, type ShaderType } from './compiler'
+import { isWholeProgramTarget, type Bindings, type ReflectionJSON, type RunnableShaderType, type ShaderType } from './compiler'
 import { demoList } from './demo-list'
 import { compressToBase64URL, decompressFromBase64URL, getResourceCommandsFromAttributes, getUniformSize, getUniformSliders, isWebGPUSupported, parseCallCommands, type CallCommand, type ResourceCommand, type UniformController } from './util'
 import type { ThreadGroupSize } from './slang-wasm'
@@ -227,7 +227,7 @@ function compileOrRun() {
 export type CompiledPlayground = {
     slangSource: string,
     shader: Shader,
-    mainEntryPoint: "imageMain" | "printMain",
+    mainEntryPoint: RunnableShaderType,
     resourceCommands: ResourceCommand[],
     callCommands: CallCommand[],
     uniformSize: number,

--- a/src/App.vue
+++ b/src/App.vue
@@ -226,8 +226,8 @@ function compileOrRun() {
 
 export type CompiledPlayground = {
     slangSource: string,
-    mainShader: Shader,
-    callCommandEntryPoints: string[],
+    shader: Shader,
+    mainEntryPoint: "imageMain" | "printMain",
     resourceCommands: ResourceCommand[],
     callCommands: CallCommand[],
     uniformSize: number,
@@ -269,13 +269,6 @@ function doRun() {
         throw new Error("Error while parsing '//! CALL' commands: " + error.message);
     }
 
-    let callCommandEntryPoints: string[] = [];
-    if (callCommands && (callCommands.length > 0)) {
-        for (const command of callCommands) {
-            callCommandEntryPoints.push(command.fnName);
-        }
-    }
-
     if (compiler == null) {
         throw new Error("Could not get compiler");
     }
@@ -283,8 +276,8 @@ function doRun() {
 
     renderCanvas.value.onRun({
         slangSource: userSource,
-        mainShader: ret,
-        callCommandEntryPoints,
+        shader: ret,
+        mainEntryPoint: entryPointName,
         resourceCommands,
         callCommands,
         uniformSize,
@@ -333,7 +326,6 @@ export type Shader = {
     hashedStrings: any,
     reflection: ReflectionJSON,
     threadGroupSize: { [key: string]: ThreadGroupSize },
-    entryPoint: string,
 };
 
 export type MaybeShader = Shader | {
@@ -361,7 +353,7 @@ function compileShader(userSource: string, entryPoint: string, compileTarget: ty
     window.$jsontree.setJson("reflectionDiv", reflectionJson);
     window.$jsontree.refreshAll();
 
-    return { succ: true, code: compiledCode, layout: layout, hashedStrings: hashedStrings, reflection: reflectionJson, threadGroupSize: threadGroupSize, entryPoint };
+    return { succ: true, code: compiledCode, layout: layout, hashedStrings: hashedStrings, reflection: reflectionJson, threadGroupSize: threadGroupSize };
 }
 
 function restoreSelectedTargetFromURL() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -227,7 +227,7 @@ function compileOrRun() {
 export type CompiledPlayground = {
     slangSource: string,
     mainShader: Shader,
-    callCommandShaders: Shader[],
+    callCommandEntryPoints: string[],
     resourceCommands: ResourceCommand[],
     callCommands: CallCommand[],
     uniformSize: number,
@@ -269,14 +269,10 @@ function doRun() {
         throw new Error("Error while parsing '//! CALL' commands: " + error.message);
     }
 
-    let callCommandShaders: Shader[] = [];
+    let callCommandEntryPoints: string[] = [];
     if (callCommands && (callCommands.length > 0)) {
         for (const command of callCommands) {
-            const compiledResult = compileShader(userSource, command.fnName, "WGSL");
-            if (!compiledResult.succ) {
-                throw new Error("Failed to compile shader for requested entry-point: " + command.fnName);
-            }
-            callCommandShaders.push(compiledResult);
+            callCommandEntryPoints.push(command.fnName);
         }
     }
 
@@ -288,7 +284,7 @@ function doRun() {
     renderCanvas.value.onRun({
         slangSource: userSource,
         mainShader: ret,
-        callCommandShaders,
+        callCommandEntryPoints,
         resourceCommands,
         callCommands,
         uniformSize,
@@ -336,7 +332,7 @@ export type Shader = {
     layout: Bindings,
     hashedStrings: any,
     reflection: ReflectionJSON,
-    threadGroupSize: ThreadGroupSize | { x: number, y: number, z: number },
+    threadGroupSize: { [key: string]: ThreadGroupSize },
     entryPoint: string,
 };
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3,7 +3,7 @@ import type { ComponentType, EmbindString, GlobalSession, MainModule, Module, Pr
 import { playgroundSource } from "./playgroundShader.js";
 
 export function isWholeProgramTarget(compileTarget: string) {
-    return compileTarget == "METAL" || compileTarget == "SPIRV";
+    return compileTarget == "METAL" || compileTarget == "SPIRV" || compileTarget == "WGSL";
 }
 
 export const RUNNABLE_ENTRY_POINT_NAMES = ['imageMain', 'printMain'] as const;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -243,9 +243,10 @@ export class SlangCompiler {
     // we will also add them to the dropdown list.
     findDefinedEntryPoints(shaderSource: string): string[] {
         let result: string[] = [];
+        let runnable: string[] = [];
         for (let entryPointName of RUNNABLE_ENTRY_POINT_NAMES) {
             if (shaderSource.match(entryPointName)) {
-                result.push(entryPointName);
+                runnable.push(entryPointName);
             }
         }
         let slangSession: Session | null | undefined;
@@ -256,7 +257,7 @@ export class SlangCompiler {
                 return [];
             }
             let module: Module | null = null;
-            if (result.length > 0) {
+            if (runnable.length > 0) {
                 slangSession.loadModuleFromSource(playgroundSource, "playground", "/playground.slang");
             }
             module = slangSession.loadModuleFromSource(shaderSource, "user", "/user.slang");
@@ -278,6 +279,7 @@ export class SlangCompiler {
             if (slangSession)
                 slangSession.delete();
         }
+        result.push(...runnable);
         return result;
     }
 
@@ -342,7 +344,7 @@ export class SlangCompiler {
 
         // If entry point is provided, we know for sure this is not a whole program compilation,
         // so we will just go to find the correct module to include in the compilation.
-        if (entryPointName != "") {
+        if (entryPointName != "" && !isWholeProgram) {
             if (this.isRunnableEntryPoint(entryPointName)) {
                 // we use the same entry point name as module name
                 const mainProgram = this.getPrecompiledProgram(slangSession, entryPointName);

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -714,12 +714,13 @@ function onRun(compiledCode: CompiledPlayground) {
             if (extraComputePipelines.length > 0)
                 extraComputePipelines = []; // This should release the resources of the extra pipelines.
 
-            for (const callShader of compiledCode.callCommandShaders) {
-                const module = device.createShaderModule({ code: callShader.code });
+            const module = device.createShaderModule({ code: compiledCode.mainShader.code });
+
+            for (const entryPoint of compiledCode.callCommandEntryPoints) {
                 const pipeline = new ComputePipeline(device);
-                pipeline.createPipelineLayout(callShader.layout);
-                pipeline.createPipeline(module, callShader.entryPoint, null);
-                pipeline.setThreadGroupSize(callShader.threadGroupSize);
+                pipeline.createPipelineLayout(compiledCode.mainShader.layout);
+                pipeline.createPipeline(module, entryPoint, null);
+                pipeline.setThreadGroupSize(compiledCode.mainShader.threadGroupSize[entryPoint]);
                 extraComputePipelines.push(pipeline);
             }
 
@@ -742,7 +743,6 @@ function onRun(compiledCode: CompiledPlayground) {
             passThroughPipeline.inputTexture = outputTexture;
             passThroughPipeline.createBindGroup();
 
-            const module = device.createShaderModule({ code: compiledCode.mainShader.code });
             computePipeline.createPipeline(module, compiledCode.mainShader.entryPoint, allocatedResources);
 
             // Create bind groups for the extra pipelines

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -705,22 +705,23 @@ function onRun(compiledCode: CompiledPlayground) {
     withRenderLock(
         // setupFn
         async () => {
-            hashedStrings = compiledCode.mainShader.hashedStrings;
+            hashedStrings = compiledCode.shader.hashedStrings;
 
-            resourceBindings = compiledCode.mainShader.layout;
+            resourceBindings = compiledCode.shader.layout;
             // create a pipeline resource 'signature' based on the bindings found in the program.
             computePipeline.createPipelineLayout(resourceBindings);
 
             if (extraComputePipelines.length > 0)
                 extraComputePipelines = []; // This should release the resources of the extra pipelines.
 
-            const module = device.createShaderModule({ code: compiledCode.mainShader.code });
+            const module = device.createShaderModule({ code: compiledCode.shader.code });
 
-            for (const entryPoint of compiledCode.callCommandEntryPoints) {
+            for (const callCommand of compiledCode.callCommands) {
+                const entryPoint = callCommand.fnName;
                 const pipeline = new ComputePipeline(device);
-                pipeline.createPipelineLayout(compiledCode.mainShader.layout);
+                pipeline.createPipelineLayout(compiledCode.shader.layout);
                 pipeline.createPipeline(module, entryPoint, null);
-                pipeline.setThreadGroupSize(compiledCode.mainShader.threadGroupSize[entryPoint]);
+                pipeline.setThreadGroupSize(compiledCode.shader.threadGroupSize[entryPoint]);
                 extraComputePipelines.push(pipeline);
             }
 
@@ -743,7 +744,7 @@ function onRun(compiledCode: CompiledPlayground) {
             passThroughPipeline.inputTexture = outputTexture;
             passThroughPipeline.createBindGroup();
 
-            computePipeline.createPipeline(module, compiledCode.mainShader.entryPoint, allocatedResources);
+            computePipeline.createPipeline(module, compiledCode.mainEntryPoint, allocatedResources);
 
             // Create bind groups for the extra pipelines
             for (const pipeline of extraComputePipelines)

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -584,7 +584,7 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
                 randomPipeline.createPipelineLayout(layout);
 
                 // Create the pipeline (without resource bindings for now)
-                randomPipeline.createPipeline(module, null);
+                randomPipeline.createPipeline(module, "computeMain", null);
 
                 randFloatPipeline = randomPipeline;
             }
@@ -718,7 +718,7 @@ function onRun(compiledCode: CompiledPlayground) {
                 const module = device.createShaderModule({ code: callShader.code });
                 const pipeline = new ComputePipeline(device);
                 pipeline.createPipelineLayout(callShader.layout);
-                pipeline.createPipeline(module, null);
+                pipeline.createPipeline(module, callShader.entryPoint, null);
                 pipeline.setThreadGroupSize(callShader.threadGroupSize);
                 extraComputePipelines.push(pipeline);
             }
@@ -743,7 +743,7 @@ function onRun(compiledCode: CompiledPlayground) {
             passThroughPipeline.createBindGroup();
 
             const module = device.createShaderModule({ code: compiledCode.mainShader.code });
-            computePipeline.createPipeline(module, allocatedResources);
+            computePipeline.createPipeline(module, compiledCode.mainShader.entryPoint, allocatedResources);
 
             // Create bind groups for the extra pipelines
             for (const pipeline of extraComputePipelines)

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -46,13 +46,13 @@ export class ComputePipeline {
         this.pipelineLayout = layout;
     }
 
-    createPipeline(shaderModule: GPUShaderModule, resources: Map<string, GPUTexture | GPUBuffer> | null) {
+    createPipeline(shaderModule: GPUShaderModule, entryPoint: string, resources: Map<string, GPUTexture | GPUBuffer> | null) {
         if (this.pipelineLayout == undefined)
             throw new Error("Cannot create pipeline without layout");
         const pipeline = this.device.createComputePipeline({
             label: 'compute pipeline',
             layout: this.pipelineLayout,
-            compute: { module: shaderModule },
+            compute: { module: shaderModule, entryPoint },
         });
 
         this.pipeline = pipeline;


### PR DESCRIPTION
WGSL allows multiple entrypoints per program.

I've also updated the WebGPU compute pipeline to make use of this by compiling a single shader module for the whole program and sharing it amongst all entrypoint dispatches.