### PR TITLE
Convert call commands to user attributes

### DIFF
--- a/public/demos/gsplat2d-diff.slang
+++ b/public/demos/gsplat2d-diff.slang
@@ -40,7 +40,7 @@ static const float ADAM_EPSILON = 1e-8;
 
 // ------ Global buffers and textures --------
 
-// The "//!" directives instruct slang-playground to allocate and initialize the buffers 
+// The playground attributes instruct slang-playground to allocate and initialize the buffers 
 // with the appropriate data. 
 //
 // When using this sample code locally, your own engine is responsible for allocating, 
@@ -857,9 +857,18 @@ float loss(uint2 dispatchThreadID, int2 imageSize)
     return 0.f;
 }
 
+// Sequence of additional kernel calls to be performed before imageMain
+// By default, imageMain is always the last kernel to be dispatched
+//
+// playground::CALL is a slang-playground directive that helps us queue up additional kernels.
+// Note that if this sample code is outside the playground, your engine is responsible for
+// dispatching these kernels in this order.
+//
+
 /*
 * clearDerivativesMain() is a kernel that resets the derivative buffer to all 0s
 */
+[playground::CALL::SIZE_OF("derivBuffer")]
 [shader("compute")]
 [numthreads(64, 1, 1)]
 void clearDerivativesMain(uint2 dispatchThreadID : SV_DispatchThreadID)
@@ -876,6 +885,7 @@ void clearDerivativesMain(uint2 dispatchThreadID : SV_DispatchThreadID)
 * It uses Slang's auto-diff capabilities by simply calling `bwd_diff()` on the loss function to generate a new function
 * that is the derivative of the loss function.
 */
+[playground::CALL::SIZE_OF("targetTexture")]
 [shader("compute")]
 [numthreads(16, 16, 1)]
 void computeDerivativesMain(uint2 dispatchThreadID : SV_DispatchThreadID)
@@ -904,6 +914,7 @@ void computeDerivativesMain(uint2 dispatchThreadID : SV_DispatchThreadID)
 * persists across iterations to help stabilize the optimization process.
 *
 */
+[playground::CALL::SIZE_OF("blobsBuffer")]
 [shader("compute")]
 [numthreads(256, 1, 1)]
 void updateBlobsMain(uint2 dispatchThreadID: SV_DispatchThreadID)
@@ -938,18 +949,6 @@ void updateBlobsMain(uint2 dispatchThreadID: SV_DispatchThreadID)
 
     blobsBuffer[globalID] -= update;
 }
-
-// Sequence of additional kernel calls to be performed before imageMain
-// By default, imageMain is always the last kernel to be dispatched
-// 
-// "//! CALL" is a slang-playground directive that helps us queue up additional kernels.
-// Note that if this sample code is outside the playground, your engine is responsible for
-// dispatching these kernels in this order.
-//
-//! CALL(clearDerivativesMain, SIZE_OF(blobsBuffer))
-//! CALL(computeDerivativesMain, SIZE_OF(targetTexture))
-//! CALL(updateBlobsMain, SIZE_OF(blobsBuffer))
-//
 
 float4 imageMain(uint2 dispatchThreadID, uint2 screenSize)
 {

--- a/public/demos/multiple-kernels.slang
+++ b/public/demos/multiple-kernels.slang
@@ -4,6 +4,7 @@ import playground;
 RWStructuredBuffer<float> buf;
 
 // Fills buffer with a sine wave
+[playground::CALL::SIZE_OF("buf")]
 [shader("compute")]
 [numthreads(64, 1, 1)]
 void fillBuffer(uint2 dispatchThreadId : SV_DispatchThreadID)
@@ -11,8 +12,6 @@ void fillBuffer(uint2 dispatchThreadId : SV_DispatchThreadID)
     uint idx = dispatchThreadId.x;
     buf[idx] = sin(float(idx) / 1000.0);
 }
-
-//! CALL(fillBuffer, SIZE_OF(buf))
 
 float4 imageMain(uint2 dispatchThreadID, int2 screenSize)
 {

--- a/src/App.vue
+++ b/src/App.vue
@@ -280,10 +280,10 @@ function doRun() {
 
     let callCommands: CallCommand[] | null = null;
     try {
-        callCommands = parseCallCommands(userSource, ret.reflection);
+        callCommands = parseCallCommands(ret.reflection);
     }
     catch (error: any) {
-        throw new Error("Error while parsing '//! CALL' commands: " + error.message);
+        throw new Error("Error while parsing CALL commands: " + error.message);
     }
 
     if (compiler == null) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -104,19 +104,22 @@ export type ReflectionParameter = {
     "binding": ReflectionBinding,
     "name": string,
     "type": ReflectionType,
-    "userAttribs"?: {
-        "arguments": any[],
-        "name": string,
-    }[],
+    "userAttribs"?: ReflectionUserAttribute[],
 }
 
 export type ReflectionJSON = {
     "entryPoints": {
         "name": string,
         "semanticName": string,
-        "type": unknown
+        "type": unknown,
+        "userAttribs"?: ReflectionUserAttribute[],
     }[],
     "parameters": ReflectionParameter[],
+};
+
+export type ReflectionUserAttribute = {
+    "arguments": (number | string)[],
+    "name": string,
 };
 
 

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -63,10 +63,10 @@ defineExpose({
         Control a float uniform with a provided default, minimum, and maximum.
         <li><code>[playground::COLOR_PICK(0.5, 0.5, 0.5)]</code></li>
         Control a float3 color uniform with a provided default color.
-        <li><code>//! CALL(fn-name, SIZE_OF(RESOURCE-NAME))</code></li>
-        Dispatch a compute pass with the given function name and using the resource size to determine the work-group
-        size.
-        <li><code>//! CALL(fn-name, 512, 512)</code></li>
+        <li><code>[playground::CALL::SIZE_OF("RESOURCE-NAME")]</code></li>
+        Dispatch a compute pass using the resource size to determine the work-group size.
+        <li><code>[playground::CALL(512, 512, 1)]</code></li>
+        Dispatch a compute pass with the given work-group size.
       </ul>
       <p>Dispatch a compute pass with the given function name and the provided work-group size.</p>
       <h4>Playground functions</h4>

--- a/src/playgroundShader.ts
+++ b/src/playgroundShader.ts
@@ -145,4 +145,18 @@ public struct playground_COLOR_PICKAttribute
     float defaultBlue;
 };
 
+[__AttributeUsage(_AttributeTargets.Function)]
+public struct playground_CALLAttribute
+{
+    int x;
+    int y;
+    int z;
+};
+
+[__AttributeUsage(_AttributeTargets.Function)]
+public struct playground_CALL_SIZE_OFAttribute
+{
+    string resourceName;
+};
+
 `;

--- a/src/util.ts
+++ b/src/util.ts
@@ -265,38 +265,39 @@ export type CallCommand = {
     size: number[],
 };
 
-export function parseCallCommands(userSource: string, reflection: ReflectionJSON): CallCommand[] {
-    // Look for commands of the form:
-    //
-    // 1. //! CALL(fn-name, SIZE_OF(<resource-name>)) ==> Dispatch a compute pass with the given 
-    //                                                    function name and using the resource size
-    //                                                    to determine the work-group size.
-    // 2. //! CALL(fn-name, 512, 512) ==> Dispatch a compute pass with the given function name and
-    //                                    the provided work-group size.
-    //
-
+export function parseCallCommands(reflection: ReflectionJSON): CallCommand[] {
     const callCommands: CallCommand[] = [];
-    const lines = userSource.split('\n');
-    for (let line of lines) {
-        const match = line.match(/\/\/!\s+CALL\((\w+),\s*(.*)\)/);
-        if (match) {
-            const fnName = match[1];
-            const args = match[2].split(',').map(arg => arg.trim());
 
-            if (args[0].startsWith("SIZE_OF")) {
-                let resourceName = args[0].slice(8, -1);
-                let resourceReflection = reflection.parameters.find((param) => param.name == resourceName);
-                if (resourceReflection == undefined) {
+    for (let entryPoint of reflection.entryPoints) {
+        const fnName = entryPoint.name;
+        if (!entryPoint.userAttribs) continue;
+
+        for (let attribute of entryPoint.userAttribs) {
+            if (attribute.name === "playground_CALL_SIZE_OF") {
+                const resourceName = attribute.arguments[0] as string;
+                const resourceReflection = reflection.parameters.find((param) => param.name === resourceName);
+
+                if (!resourceReflection) {
                     throw new Error(`Cannot find resource ${resourceName} for ${fnName} CALL command`)
                 }
+
                 let elementSize: number | undefined = undefined;
-                if (resourceReflection.type.kind == "resource" && resourceReflection.type.baseShape == "structuredBuffer") {
+                if (resourceReflection.type.kind === "resource" && resourceReflection.type.baseShape === "structuredBuffer") {
                     elementSize = getSize(resourceReflection.type.resultType);
                 }
-                callCommands.push({ type: "RESOURCE_BASED", fnName, resourceName, elementSize });
-            }
-            else {
-                callCommands.push({ type: "FIXED_SIZE", fnName, size: args.map(Number) });
+
+                callCommands.push({
+                    type: "RESOURCE_BASED",
+                    fnName,
+                    resourceName,
+                    elementSize
+                });
+            } else if (attribute.name === "playground_CALL") {
+                callCommands.push({
+                    type: "FIXED_SIZE",
+                    fnName,
+                    size: attribute.arguments as number[]
+                });
             }
         }
     }


### PR DESCRIPTION
This follows up on #87 to convert the CALL commands to attributes as well.

https://github.com/shader-slang/slang/pull/6366 needs to be merged first to expose the required information in the reflection JSON.