### PR TITLE
Support BLACK_SCREEN, add format inference, and add new demo

### DIFF
--- a/public/demos/gsplat2d-diff.slang
+++ b/public/demos/gsplat2d-diff.slang
@@ -60,6 +60,7 @@ RWStructuredBuffer<float> adamFirstMoment;
 RWStructuredBuffer<float> adamSecondMoment;
 
 [playground::URL("static/jeep.jpg")]
+[format("rgba8")]
 Texture2D<float4> targetTexture;
 
 // ----- Shared memory declarations --------

--- a/public/demos/image-from-url.slang
+++ b/public/demos/image-from-url.slang
@@ -3,6 +3,7 @@
 import playground;
 
 [playground::URL("static/jeep.jpg")]
+[format("rgba8")]
 Texture2D<float4> myImage;
 
 float4 imageMain(uint2 dispatchThreadID, int2 screenSize)

--- a/public/demos/painting.slang
+++ b/public/demos/painting.slang
@@ -1,0 +1,46 @@
+import playground;
+
+const static int MAX_BRUSH_SIZE = 16;
+
+[playground::BLACK_SCREEN(1.0, 1.0)]
+RWTexture2D<float> tex_red;
+[playground::BLACK_SCREEN(1.0, 1.0)]
+RWTexture2D<float> tex_green;
+[playground::BLACK_SCREEN(1.0, 1.0)]
+RWTexture2D<float> tex_blue;
+
+[playground::SLIDER(10.0, 4.0, 16.0)]
+uniform float brush_size;
+[playground::COLOR_PICK(1.0, 0.0, 1.0)]
+uniform float3 color;
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+[playground::CALL(MAX_BRUSH_SIZE, MAX_BRUSH_SIZE, 1)]
+void draw(uint2 dispatchThreadId: SV_DispatchThreadID)
+{
+    if (getMousePosition().z >= 0)
+        return;
+
+    let offset = float2(dispatchThreadId.xy) - float(MAX_BRUSH_SIZE) / 2;
+    if (length(offset) > brush_size / 2)
+        return;
+
+    var mouse_pos = uint2(getMousePosition().xy + offset);
+    tex_red[mouse_pos] = color.r;
+    tex_green[mouse_pos] = color.g;
+    tex_blue[mouse_pos] = color.b;
+}
+
+float4 imageMain(uint2 dispatchThreadID, int2 screenSize)
+{
+    uint imageW;
+    uint imageH;
+    tex_red.GetDimensions(imageW, imageH);
+
+    uint2 scaled = (uint2)floor(float2(dispatchThreadID.xy));
+    uint2 flipped = uint2(scaled.x, imageH - scaled.y);
+
+    float4 imageColor = float4(tex_red[flipped], tex_green[flipped], tex_blue[flipped], 1.0);
+    return imageColor;
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -351,7 +351,7 @@ export type Shader = {
     layout: Bindings,
     hashedStrings: HashedStringData[],
     reflection: ReflectionJSON,
-    threadGroupSize: { [key: string]: ThreadGroupSize },
+    threadGroupSizes: { [key: string]: [number, number, number] },
 };
 
 export type MaybeShader = Shader | {
@@ -369,7 +369,7 @@ function compileShader(userSource: string, entryPoint: string, compileTarget: ty
         return { succ: false };
     }
 
-    let [compiledCode, layout, hashedStrings, reflectionJsonObj, threadGroupSize] = compiledResult;
+    let [compiledCode, layout, hashedStrings, reflectionJsonObj, threadGroupSizes] = compiledResult;
     reflectionJson = reflectionJsonObj;
 
     codeGenArea.value?.setEditorValue(compiledCode);
@@ -379,7 +379,7 @@ function compileShader(userSource: string, entryPoint: string, compileTarget: ty
     window.$jsontree.setJson("reflectionDiv", reflectionJson);
     window.$jsontree.refreshAll();
 
-    return { succ: true, code: compiledCode, layout: layout, hashedStrings: hashedStrings, reflection: reflectionJson, threadGroupSize: threadGroupSize };
+    return { succ: true, code: compiledCode, layout: layout, hashedStrings: hashedStrings, reflection: reflectionJson, threadGroupSizes };
 }
 
 function restoreFromURL(): boolean {

--- a/src/App.vue
+++ b/src/App.vue
@@ -349,7 +349,7 @@ export type Shader = {
     succ: true,
     code: string,
     layout: Bindings,
-    hashedStrings: HashedStringData[],
+    hashedStrings: HashedStringData,
     reflection: ReflectionJSON,
     threadGroupSizes: { [key: string]: [number, number, number] },
 };
@@ -379,7 +379,7 @@ function compileShader(userSource: string, entryPoint: string, compileTarget: ty
     window.$jsontree.setJson("reflectionDiv", reflectionJson);
     window.$jsontree.refreshAll();
 
-    return { succ: true, code: compiledCode, layout: layout, hashedStrings: hashedStrings, reflection: reflectionJson, threadGroupSizes };
+    return { succ: true, code: compiledCode, layout: layout, hashedStrings, reflection: reflectionJson, threadGroupSizes };
 }
 
 function restoreFromURL(): boolean {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -3,7 +3,7 @@ import type { ComponentType, EmbindString, GlobalSession, MainModule, Module, Pr
 import playgroundSource from "./slang/playground.slang?raw";
 import imageMainSource from "./slang/imageMain.slang?raw";
 import printMainSource from "./slang/printMain.slang?raw";
-import { sizeFromFormat, type HashedStringData } from "./util.js";
+import { ACCESS_MAP, getTextureFormat, sizeFromFormat, webgpuFormatfromSlangFormat, type HashedStringData, type ScalarType, type SlangFormat } from "./util.js";
 
 export function isWholeProgramTarget(compileTarget: string) {
     return compileTarget == "METAL" || compileTarget == "SPIRV" || compileTarget == "WGSL";
@@ -18,16 +18,7 @@ const RUNNABLE_ENTRY_POINT_SOURCE_MAP: { [key in RunnableShaderType]: string } =
     'printMain': printMainSource,
 };
 
-const ACCESS_MAP = {
-    "readWrite": "read-write",
-    "write": "write-only"
-} as const;
-
 export type Bindings = Map<string, GPUBindGroupLayoutEntry>;
-
-export type ScalarType = `${"uint" | "int"}${8 | 16 | 32 | 64}` | `${"float"}${16 | 32 | 64}`;
-
-export type SlangFormat = "rgba32f" | "rgba16f" | "rg32f" | "rg16f" | "r11f_g11f_b10f" | "r32f" | "r16f" | "rgba16" | "rgb10_a2" | "rgba8" | "rg16" | "rg8" | "r16" | "r8" | "rgba16_snorm" | "rgba8_snorm" | "rg16_snorm" | "rg8_snorm" | "r16_snorm" | "r8_snorm" | "rgba32i" | "rgba16i" | "rgba8i" | "rg32i" | "rg16i" | "rg8i" | "r32i" | "r16i" | "r8i" | "rgba32ui" | "rgba16ui" | "rgb10_a2ui" | "rgba8ui" | "rg32ui" | "rg16ui" | "rg8ui" | "r32ui" | "r16ui" | "r8ui" | "64ui" | "r64i" | "bgra8"
 
 export type ReflectionBinding = {
     "kind": "uniform",
@@ -557,87 +548,3 @@ export class SlangCompiler {
         }
     }
 };
-
-type ScalarRepresentation = `8unorm` | `${16 | 32}float` | `${8 | 16 | 32}${"sint" | "uint"}`;
-function getWebGPURepresentation(scalarType: ScalarType): ScalarRepresentation {
-    let size = parseInt(scalarType.replace(/^[a-z]*/, ""));
-    let type = scalarType.replace(/[0-9]*$/, "");
-    if (type == "int")
-        type = "sint";
-
-    return `${size}${type}` as any
-}
-
-function getScalarSize(scalarType: ScalarType): 8 | 16 | 32 | 64 {
-    let size = parseInt(scalarType.replace(/^[a-z]*/, ""));
-    return size as any;
-}
-
-function getTextureFormat(componentCount: 1 | 2 | 3 | 4, scalarType: ScalarType, access: GPUStorageTextureAccess | undefined): GPUTextureFormat {
-    if (access == "read-write" && componentCount > 1) {
-        throw new Error("There are no texture formats available with more than 1 component that are read-write")
-    }
-    let scalarSize = getScalarSize(scalarType);
-
-    if (access == "write-only" && componentCount == 2 && scalarSize != 32) {
-        throw new Error("There are no non 32 bit texture formats available with 2 components that are write-only")
-    }
-
-    if (scalarSize == 64) {
-        throw new Error("There are 64 bit texture formats available")
-    }
-
-    let scalarRepresentation = getWebGPURepresentation(scalarType);
-    if (componentCount == 1) {
-        return `r${scalarRepresentation}`
-    } else if (componentCount == 2) {
-        return `rg${scalarRepresentation}`
-    } else {
-        return `rgba${scalarRepresentation}`
-    }
-}
-
-const FORMAT_MAP: Partial<Record<SlangFormat, GPUTextureFormat>> = {
-    "rgba32f": "rgba32float",
-    "rgba16f": "rgba16float",
-    "rg32f": "rg32float",
-    "rg16f": "rg16float",
-    "r32f": "r32float",
-    "r16f": "r16float",
-    "rgb10_a2": "rgb10a2unorm",
-    "rgba8": "rgba8unorm",
-    "rg8": "rg8unorm",
-    "r8": "r8unorm",
-    "rgba8_snorm": "rgba8snorm",
-    "rg8_snorm": "rg8snorm",
-    "r8_snorm": "r8snorm",
-    "rgba32i": "rgba32sint",
-    "rgba16i": "rgba16sint",
-    "rgba8i": "rgba8sint",
-    "rg32i": "rg32sint",
-    "rg16i": "rg16sint",
-    "rg8i": "rg8sint",
-    "r32i": "r32sint",
-    "r16i": "r16sint",
-    "r8i": "r8sint",
-    "rgba32ui": "rgba32uint",
-    "rgba16ui": "rgba16uint",
-    "rgb10_a2ui": "rgb10a2uint",
-    "rgba8ui": "rgba8uint",
-    "rg32ui": "rg32uint",
-    "rg16ui": "rg16uint",
-    "rg8ui": "rg8uint",
-    "r32ui": "r32uint",
-    "r16ui": "r16uint",
-    "r8ui": "r8uint",
-    "bgra8": "bgra8unorm"
-}
-
-function webgpuFormatfromSlangFormat(format: SlangFormat): GPUTextureFormat {
-    let gpuFormat = FORMAT_MAP[format];
-    if (gpuFormat == undefined) {
-        throw new Error(`Could not find webgpu format for ${format}`);
-    }
-    return gpuFormat;
-}
-

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -372,12 +372,14 @@ export class SlangCompiler {
                 return { buffer: { type: 'storage' } };
             } else {
                 let _: never = parameterReflection.type;
-                throw new Error(`Could not generate binding for ${name}`)
+                console.error(`Could not generate binding for ${name}`)
+                return {}
             }
         } else if (parameterReflection.binding.kind == "uniform") {
             return { buffer: { type: 'uniform' } };
         } else {
-            throw new Error(`Could not generate binding for ${name}`)
+            console.error(`Could not generate binding for ${name}`)
+            return {}
         }
     }
 

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -818,7 +818,7 @@ function onRun(runCompiledCode: CompiledPlayground) {
             if (compiler == null) {
                 throw new Error("Could not get compiler");
             }
-            if (compiler.shaderType !== null) {
+            if (compiler.shaderType !== null && !abortRender) {
                 const keepRendering = await execFrame(timeMS, compiler?.shaderType || null, compiledCode, firstFrame);
                 firstFrame = false;
                 return keepRendering;

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -305,7 +305,6 @@ async function execFrame(timeMS: number, currentDisplayMode: ShaderType, playgro
 
     for (let uniformComponent of playgroundData.uniformComponents.value) {
         let offset = uniformComponent.buffer_offset;
-        try {
         if (uniformComponent.type == "SLIDER") {
             uniformBufferView.setFloat32(offset, uniformComponent.value, true);
         } else if (uniformComponent.type == "COLOR_PICK") {
@@ -322,10 +321,6 @@ async function execFrame(timeMS: number, currentDisplayMode: ShaderType, playgro
         } else {
             let _: never = uniformComponent;
             throw new Error("Invalid state");
-        }
-        } catch (error) {
-            emit("logError", "Error when writing to uniform buffer: " + error);
-            return false;
         }
     }
 

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -175,7 +175,7 @@ function handleResize() {
                 throw new Error(`Resource ${resourceName} is not defined in the bindings.`);
             }
 
-            const format = bindingInfo.storageTexture?.format; // TODO:better inference
+            const format = bindingInfo.storageTexture?.format;
             if (format == undefined) {
                 throw new Error("Could not find format")
             }
@@ -506,7 +506,7 @@ async function processResourceCommands(resourceBindings: Bindings, resourceComma
                 throw new Error(`Resource ${resourceName} is not defined in the bindings.`);
             }
 
-            const format = bindingInfo.storageTexture?.format; // TODO:better inference
+            const format = bindingInfo.storageTexture?.format;
             if (format == undefined) {
                 throw new Error("Could not find format")
             }
@@ -546,7 +546,7 @@ async function processResourceCommands(resourceBindings: Bindings, resourceComma
             }
 
 
-            const format = bindingInfo.storageTexture?.format; // TODO:better inference
+            const format = bindingInfo.storageTexture?.format;
             if (format == undefined) {
                 throw new Error("Could not find format")
             }

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -4,20 +4,18 @@ import type { Bindings, ShaderType } from '../compiler';
 import { ComputePipeline } from '../compute';
 import { GraphicsPipeline, passThroughshaderCode } from '../pass_through';
 import { compiler } from '../try-slang';
-import { type CallCommand, createOutputTexture, type HashedStringData, NotReadyError, parsePrintfBuffer, type ResourceCommand } from '../util';
+import { type CallCommand, type HashedStringData, NotReadyError, parsePrintfBuffer, type ResourceCommand, sizeFromFormat } from '../util';
 import { onMounted, ref, useTemplateRef } from 'vue';
 import randFloatShaderCode from "../slang/rand_float.slang?raw";
 
 let context: GPUCanvasContext;
 let randFloatPipeline: ComputePipeline;
-let computePipeline: ComputePipeline;
-let extraComputePipelines: ComputePipeline[] = [];
+let computePipelines: ComputePipeline[] = [];
 let passThroughPipeline: GraphicsPipeline;
 
-let resourceBindings: Bindings;
+let compiledCode: CompiledPlayground;
 let allocatedResources: Map<string, GPUTexture | GPUBuffer>;
 let randFloatResources: Map<string, GPUObjectBase>;
-let hashedStrings: HashedStringData[];
 
 let renderThread: Promise<void> | null = null;
 let abortRender = false;
@@ -160,19 +158,74 @@ function withRenderLock(setupFn: { (): Promise<void>; }, renderFn: { (timeMS: nu
 }
 
 function handleResize() {
-    if (!computePipeline || !passThroughPipeline)
+    if (!passThroughPipeline)
         return;
 
     if (currentWindowSize[0] < 2 || currentWindowSize[1] < 2)
         return;
 
-    safeSet(allocatedResources, "outputTexture", createOutputTexture(device, currentWindowSize[0], currentWindowSize[1], 'rgba8unorm'));
-    computePipeline.createBindGroup(allocatedResources);
+    for (const { resourceName, parsedCommand } of compiledCode.resourceCommands) {
+        if (parsedCommand.type === "BLACK_SCREEN") {
+            const width = parsedCommand.width_scale * currentWindowSize[0];
+            const height = parsedCommand.height_scale * currentWindowSize[1];
+            const size = width * height;
+
+            const bindingInfo = compiledCode.shader.layout.get(resourceName);
+            if (!bindingInfo) {
+                throw new Error(`Resource ${resourceName} is not defined in the bindings.`);
+            }
+
+            const format = bindingInfo.storageTexture?.format; // TODO:better inference
+            if (format == undefined) {
+                throw new Error("Could not find format")
+            }
+            const elementSize = sizeFromFormat(format);
+
+            if (!bindingInfo.texture && !bindingInfo.storageTexture) {
+                throw new Error(`Resource ${resourceName} is an invalid type for BLACK`);
+            }
+            try {
+                let usage = GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT;
+                if (bindingInfo.storageTexture) {
+                    usage |= GPUTextureUsage.STORAGE_BINDING;
+                }
+                const texture = device.createTexture({
+                    size: [width, height],
+                    format,
+                    usage: usage,
+                });
+
+                let zeros = new Uint8Array(Array(size * elementSize).fill(0));
+                device.queue.writeTexture({ texture }, zeros, { bytesPerRow: width * elementSize }, { width, height });
+
+                // Initialize the texture with zeros.
+                const encoder = device.createCommandEncoder({ label: 'resize encoder' });
+                let oldTexture = allocatedResources.get(resourceName);
+                if (!(oldTexture instanceof GPUTexture)) {
+                    throw new Error("Cannot resize non texture");
+                }
+                let sharedWidth = Math.min(width, oldTexture.width);
+                let sharedHeight = Math.min(height, oldTexture.height);
+                encoder.copyTextureToTexture({ texture: oldTexture }, { texture }, {
+                    width: sharedWidth,
+                    height: sharedHeight,
+                })
+                
+                let commandBuffer = encoder.finish();
+                device.queue.submit([commandBuffer]);
+
+                safeSet(allocatedResources, resourceName, texture);
+            }
+            catch (error) {
+                throw new Error(`Failed to create texture: ${error}`);
+            }
+        }
+    }
 
     passThroughPipeline.inputTexture = (allocatedResources.get("outputTexture") as GPUTexture);
     passThroughPipeline.createBindGroup();
 
-    for (const pipeline of extraComputePipelines)
+    for (const pipeline of computePipelines)
         pipeline.createBindGroup(allocatedResources);
 }
 
@@ -257,19 +310,19 @@ async function execFrame(timeMS: number, currentDisplayMode: ShaderType, playgro
     if (!(uniformInput instanceof GPUBuffer)) {
         throw new Error("uniformInput doesn't exist or is of incorrect type");
     }
-    computePipeline.device.queue.writeBuffer(uniformInput, 0, timeArray);
+    device.queue.writeBuffer(uniformInput, 0, timeArray);
 
     for (let uniformComponent of playgroundData.uniformComponents.value) {
         if (uniformComponent.type == "slider") {
             let sliderArray = new Float32Array([uniformComponent.value]);
-            computePipeline.device.queue.writeBuffer(uniformInput, uniformComponent.buffer_offset, sliderArray);
+            device.queue.writeBuffer(uniformInput, uniformComponent.buffer_offset, sliderArray);
         } else if (uniformComponent.type == "color pick") {
             let sliderArray = new Float32Array(uniformComponent.value);
-            computePipeline.device.queue.writeBuffer(uniformInput, uniformComponent.buffer_offset, sliderArray);
+            device.queue.writeBuffer(uniformInput, uniformComponent.buffer_offset, sliderArray);
         } else {
             // exhaustiveness check
-            let _:never = uniformComponent;
-            throw new Error("Invalid state"); 
+            let _: never = uniformComponent;
+            throw new Error("Invalid state");
         }
     }
 
@@ -284,14 +337,13 @@ async function execFrame(timeMS: number, currentDisplayMode: ShaderType, playgro
         encoder.clearBuffer(printfBufferRead);
     }
 
-    // The extra passes always go first.
-    // zip the extraComputePipelines and callCommands together
-    for (const [pipeline, command] of playgroundData.callCommands.map((x: CallCommand, i: number) => [extraComputePipelines[i], x] as const)) {
+    // zip the computePipelines and callCommands together
+    for (const [pipeline, command] of playgroundData.callCommands.map((x: CallCommand, i: number) => [computePipelines[i], x] as const)) {
         if (command.callOnce && !firstFrame) {
             // If the command is marked as callOnce and it's not the first frame, skip it.
             continue;
         }
-        const pass = encoder.beginComputePass({ label: 'extra passes' });
+        const pass = encoder.beginComputePass({ label: `${command.fnName} compute pass` });
         pass.setBindGroup(0, pipeline.bindGroup || null);
         if (pipeline.pipeline == undefined) {
             throw new Error("pipeline is undefined");
@@ -352,19 +404,7 @@ async function execFrame(timeMS: number, currentDisplayMode: ShaderType, playgro
         pass.end();
     }
 
-    const pass = encoder.beginComputePass({ label: 'compute builtin pass' });
-
-    pass.setBindGroup(0, computePipeline.bindGroup || null);
-    if (computePipeline.pipeline == undefined)
-        throw new Error("Compute pipeline is not defined.");
-    pass.setPipeline(computePipeline.pipeline);
-
     if (currentDisplayMode == "imageMain") {
-        const workGroupSizeX = (currentWindowSize[0] + 15) / 16;
-        const workGroupSizeY = (currentWindowSize[1] + 15) / 16;
-        pass.dispatchWorkgroups(workGroupSizeX, workGroupSizeY);
-        pass.end();
-
         const renderPassDescriptor = passThroughPipeline.createRenderPassDesc(context.getCurrentTexture().createView());
         const renderPass = encoder.beginRenderPass(renderPassDescriptor);
 
@@ -379,27 +419,10 @@ async function execFrame(timeMS: number, currentDisplayMode: ShaderType, playgro
 
     // copy output buffer back in print mode
     if (currentDisplayMode == "printMain") {
-        pass.dispatchWorkgroups(1, 1);
-        pass.end();
-
-        let outputBuffer = allocatedResources.get("outputBuffer");
-        if (!(outputBuffer instanceof GPUBuffer)) {
-            throw new Error("outputBuffer is incorrect type or doesn't exist");
-        }
-        let outputBufferRead = allocatedResources.get("outputBufferRead");
-        if (!(outputBufferRead instanceof GPUBuffer)) {
-            throw new Error("outputBufferRead is incorrect type or doesn't exist");
-        }
         let g_printedBuffer = allocatedResources.get("g_printedBuffer")
         if (!(g_printedBuffer instanceof GPUBuffer)) {
             throw new Error("g_printedBuffer is not a buffer");
         }
-        encoder.copyBufferToBuffer(
-            outputBuffer,
-            0,
-            outputBufferRead,
-            0,
-            outputBuffer.size);
         encoder.copyBufferToBuffer(
             g_printedBuffer, 0, printfBufferRead, 0, g_printedBuffer.size);
     }
@@ -415,7 +438,7 @@ async function execFrame(timeMS: number, currentDisplayMode: ShaderType, playgro
 
         let textResult = "";
         const formatPrint = parsePrintfBuffer(
-            hashedStrings,
+            compiledCode.shader.hashedStrings,
             printfBufferRead,
             printfBufferElementSize);
 
@@ -438,11 +461,8 @@ async function execFrame(timeMS: number, currentDisplayMode: ShaderType, playgro
         frameCount = 0;
     }
 
-    // Only request the next frame if we are in the render mode
-    if (currentDisplayMode == "imageMain")
-        return true;
-    else
-        return false;
+    // Request the next frame
+    return true;
 }
 
 function safeSet<T extends GPUTexture | GPUBuffer>(map: Map<string, T>, key: string, value: T) {
@@ -454,10 +474,10 @@ function safeSet<T extends GPUTexture | GPUBuffer>(map: Map<string, T>, key: str
     map.set(key, value);
 };
 
-async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipeline, resourceBindings: Bindings, resourceCommands: ResourceCommand[], uniformSize: number) {
+async function processResourceCommands(resourceBindings: Bindings, resourceCommands: ResourceCommand[], uniformSize: number) {
     let allocatedResources: Map<string, GPUBuffer | GPUTexture> = new Map();
 
-    safeSet(allocatedResources, "uniformInput", pipeline.device.createBuffer({ size: uniformSize, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST }));
+    safeSet(allocatedResources, "uniformInput", device.createBuffer({ size: uniformSize, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST }));
 
     for (const { resourceName, parsedCommand } of resourceCommands) {
         if (parsedCommand.type === "ZEROS") {
@@ -471,7 +491,7 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
                 throw new Error(`Resource ${resourceName} is an invalid type for ZEROS`);
             }
 
-            const buffer = pipeline.device.createBuffer({
+            const buffer = device.createBuffer({
                 size: parsedCommand.count * elementSize,
                 usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
             });
@@ -480,14 +500,19 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
 
             // Initialize the buffer with zeros.
             let zeros: BufferSource = new Uint8Array(parsedCommand.count * elementSize);
-            pipeline.device.queue.writeBuffer(buffer, 0, zeros);
+            device.queue.writeBuffer(buffer, 0, zeros);
         } else if (parsedCommand.type === "BLACK") {
             const size = parsedCommand.width * parsedCommand.height;
-            const elementSize = 4; // Assuming 4 bytes per element (e.g., float) TODO: infer from type.
             const bindingInfo = resourceBindings.get(resourceName);
             if (!bindingInfo) {
                 throw new Error(`Resource ${resourceName} is not defined in the bindings.`);
             }
+
+            const format = bindingInfo.storageTexture?.format; // TODO:better inference
+            if (format == undefined) {
+                throw new Error("Could not find format")
+            }
+            const elementSize = sizeFromFormat(format);
 
             if (!bindingInfo.texture && !bindingInfo.storageTexture) {
                 throw new Error(`Resource ${resourceName} is an invalid type for BLACK`);
@@ -497,9 +522,9 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
                 if (bindingInfo.storageTexture) {
                     usage |= GPUTextureUsage.STORAGE_BINDING;
                 }
-                const texture = pipeline.device.createTexture({
+                const texture = device.createTexture({
                     size: [parsedCommand.width, parsedCommand.height],
-                    format: bindingInfo.storageTexture ? 'r32float' : 'rgba8unorm',
+                    format,
                     usage: usage,
                 });
 
@@ -507,7 +532,48 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
 
                 // Initialize the texture with zeros.
                 let zeros = new Uint8Array(Array(size * elementSize).fill(0));
-                pipeline.device.queue.writeTexture({ texture }, zeros, { bytesPerRow: parsedCommand.width * elementSize }, { width: parsedCommand.width, height: parsedCommand.height });
+                device.queue.writeTexture({ texture }, zeros, { bytesPerRow: parsedCommand.width * elementSize }, { width: parsedCommand.width, height: parsedCommand.height });
+            }
+            catch (error) {
+                throw new Error(`Failed to create texture: ${error}`);
+            }
+        } else if (parsedCommand.type === "BLACK_SCREEN") {
+            const width = parsedCommand.width_scale * currentWindowSize[0];
+            const height = parsedCommand.height_scale * currentWindowSize[1];
+            const size = width * height;
+
+            const bindingInfo = resourceBindings.get(resourceName);
+            if (!bindingInfo) {
+                throw new Error(`Resource ${resourceName} is not defined in the bindings.`);
+            }
+
+
+            const format = bindingInfo.storageTexture?.format; // TODO:better inference
+            if (format == undefined) {
+                throw new Error("Could not find format")
+            }
+            const elementSize = sizeFromFormat(format);
+
+            if (!bindingInfo.texture && !bindingInfo.storageTexture) {
+                throw new Error(`Resource ${resourceName} is an invalid type for BLACK`);
+            }
+            try {
+                let usage = GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT;
+                if (bindingInfo.storageTexture) {
+                    usage |= GPUTextureUsage.STORAGE_BINDING;
+                }
+                const texture = device.createTexture({
+                    size: [width, height],
+                    format,
+                    usage: usage,
+                });
+
+                safeSet(allocatedResources, resourceName, texture);
+
+                // Initialize the texture with zeros.
+                let zeros = new Uint8Array(Array(size * elementSize).fill(0));
+                device.queue.writeTexture({ texture }, zeros, { bytesPerRow: width * elementSize }, { width, height });
+                device.queue.submit([]);
             }
             catch (error) {
                 throw new Error(`Failed to create texture: ${error}`);
@@ -540,12 +606,12 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
 
             try {
                 const imageBitmap = await createImageBitmap(image);
-                const texture = pipeline.device.createTexture({
+                const texture = device.createTexture({
                     size: [imageBitmap.width, imageBitmap.height],
                     format: 'rgba8unorm',
                     usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
                 });
-                pipeline.device.queue.copyExternalImageToTexture({ source: imageBitmap }, { texture: texture }, [imageBitmap.width, imageBitmap.height]);
+                device.queue.copyExternalImageToTexture({ source: imageBitmap }, { texture: texture }, [imageBitmap.width, imageBitmap.height]);
                 safeSet(allocatedResources, resourceName, texture);
             }
             catch (error) {
@@ -562,7 +628,7 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
                 throw new Error(`Resource ${resourceName} is not defined as a buffer.`);
             }
 
-            const buffer = pipeline.device.createBuffer({
+            const buffer = device.createBuffer({
                 size: parsedCommand.count * elementSize,
                 usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
             });
@@ -571,7 +637,7 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
 
             // Place a call to a shader that fills the buffer with random numbers.
             if (!randFloatPipeline) {
-                const randomPipeline = new ComputePipeline(pipeline.device);
+                const randomPipeline = new ComputePipeline(device);
 
                 if (compiler == null) {
                     throw new Error("Compiler is not defined!");
@@ -582,7 +648,7 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
                 }
 
                 let [code, layout] = compiledResult;
-                const module = pipeline.device.createShaderModule({ code: code });
+                const module = device.createShaderModule({ code: code });
 
                 randomPipeline.createPipelineLayout(layout);
 
@@ -604,7 +670,7 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
 
                 if (!randFloatResources.has("seed"))
                     randFloatResources.set("seed",
-                        pipeline.device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST }));
+                        device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST }));
 
                 const seedBuffer = randFloatResources.get("seed") as GPUBuffer;
 
@@ -612,10 +678,10 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
                 randFloatPipeline.createBindGroup(randFloatResources);
 
                 const seedValue = new Float32Array([Math.random(), 0, 0, 0]);
-                pipeline.device.queue.writeBuffer(seedBuffer, 0, seedValue);
+                device.queue.writeBuffer(seedBuffer, 0, seedValue);
 
                 // Encode commands to do the computation
-                const encoder = pipeline.device.createCommandEncoder({ label: 'compute builtin encoder' });
+                const encoder = device.createCommandEncoder({ label: 'compute builtin encoder' });
                 const pass = encoder.beginComputePass({ label: 'compute builtin pass' });
 
                 pass.setBindGroup(0, randomPipeline.bindGroup || null);
@@ -631,8 +697,8 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
 
                 // Finish encoding and submit the commands
                 const commandBuffer = encoder.finish();
-                pipeline.device.queue.submit([commandBuffer]);
-                await pipeline.device.queue.onSubmittedWorkDone();
+                device.queue.submit([commandBuffer]);
+                await device.queue.onSubmittedWorkDone();
             }
         } else if (parsedCommand.type == "SLIDER") {
             const elementSize = parsedCommand.elementSize;
@@ -645,7 +711,7 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
                 bufferDefault = new Float32Array([parsedCommand.default]);
             } else
                 throw new Error("Unsupported float size for slider")
-            pipeline.device.queue.writeBuffer(buffer, parsedCommand.offset, bufferDefault);
+            device.queue.writeBuffer(buffer, parsedCommand.offset, bufferDefault);
         } else if (parsedCommand.type == "COLOR_PICK") {
             const elementSize = parsedCommand.elementSize;
 
@@ -657,7 +723,7 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
                 bufferDefault = new Float32Array(parsedCommand.default);
             } else
                 throw new Error("Unsupported float size for color pick")
-            pipeline.device.queue.writeBuffer(buffer, parsedCommand.offset, bufferDefault);
+            device.queue.writeBuffer(buffer, parsedCommand.offset, bufferDefault);
         } else {
             // exhaustiveness check
             let x: never = parsedCommand;
@@ -668,25 +734,12 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
     //
     // Some special-case allocations
     //
-
-    safeSet(allocatedResources, "outputTexture", createOutputTexture(device, currentWindowSize[0], currentWindowSize[1], 'rgba8unorm'));
-
-    safeSet(allocatedResources, "outputBuffer", pipeline.device.createBuffer({
-        size: 2 * 2 * 4,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
-    }));
-
-    safeSet(allocatedResources, "outputBufferRead", pipeline.device.createBuffer({
-        size: 2 * 2 * 4,
-        usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
-    }));
-
-    safeSet(allocatedResources, "g_printedBuffer", pipeline.device.createBuffer({
+    safeSet(allocatedResources, "g_printedBuffer", device.createBuffer({
         size: printfBufferSize,
         usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
     }));
 
-    safeSet(allocatedResources, "printfBufferRead", pipeline.device.createBuffer({
+    safeSet(allocatedResources, "printfBufferRead", device.createBuffer({
         size: printfBufferSize,
         usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
     }));
@@ -694,43 +747,37 @@ async function processResourceCommands(pipeline: ComputePipeline | GraphicsPipel
     return allocatedResources;
 }
 
-function onRun(compiledCode: CompiledPlayground) {
+function onRun(runCompiledCode: CompiledPlayground) {
     if (!device)
         return;
     if (!compiler)
         return;
 
     resetMouse();
-    if (!computePipeline) {
-        computePipeline = new ComputePipeline(device);
-    }
 
     let firstFrame = true;
 
     withRenderLock(
         // setupFn
         async () => {
-            hashedStrings = compiledCode.shader.hashedStrings;
+            compiledCode = runCompiledCode;
 
-            resourceBindings = compiledCode.shader.layout;
-            // create a pipeline resource 'signature' based on the bindings found in the program.
-            computePipeline.createPipelineLayout(resourceBindings);
-
-            if (extraComputePipelines.length > 0)
-                extraComputePipelines = []; // This should release the resources of the extra pipelines.
+            if (computePipelines.length > 0)
+                computePipelines = []; // This should release the resources of the pipelines.
 
             const module = device.createShaderModule({ code: compiledCode.shader.code });
 
             for (const callCommand of compiledCode.callCommands) {
                 const entryPoint = callCommand.fnName;
                 const pipeline = new ComputePipeline(device);
+                // create a pipeline resource 'signature' based on the bindings found in the program.
                 pipeline.createPipelineLayout(compiledCode.shader.layout);
                 pipeline.createPipeline(module, entryPoint, null);
                 pipeline.setThreadGroupSize(compiledCode.shader.threadGroupSize[entryPoint]);
-                extraComputePipelines.push(pipeline);
+                computePipelines.push(pipeline);
             }
 
-            allocatedResources = await processResourceCommands(computePipeline, resourceBindings, compiledCode.resourceCommands, compiledCode.uniformSize);
+            allocatedResources = await processResourceCommands(compiledCode.shader.layout, compiledCode.resourceCommands, compiledCode.uniformSize);
 
             if (!passThroughPipeline) {
                 passThroughPipeline = new GraphicsPipeline(device);
@@ -749,10 +796,8 @@ function onRun(compiledCode: CompiledPlayground) {
             passThroughPipeline.inputTexture = outputTexture;
             passThroughPipeline.createBindGroup();
 
-            computePipeline.createPipeline(module, compiledCode.mainEntryPoint, allocatedResources);
-
-            // Create bind groups for the extra pipelines
-            for (const pipeline of extraComputePipelines)
+            // Create bind groups for the pipelines
+            for (const pipeline of computePipelines)
                 pipeline.createBindGroup(allocatedResources);
         },
         // renderFn

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -8,8 +8,6 @@ export class ComputePipeline {
     // TODO: We should make this field optional, and only when user select a "Debug" mode will this option be available,
     // and we will output this buffer to the output area.
 
-    // outputBuffer;
-    // outputBufferRead;
     // outputTexture;
     device;
     bindGroup: GPUBindGroup | undefined;

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -5,15 +5,11 @@ export class ComputePipeline {
     pipeline: GPUComputePipeline | undefined;
     pipelineLayout: GPUPipelineLayout | "auto" | undefined;
 
-    // TODO: We should make this field optional, and only when user select a "Debug" mode will this option be available,
-    // and we will output this buffer to the output area.
-
-    // outputTexture;
     device;
     bindGroup: GPUBindGroup | undefined;
 
     // thread group size (array of 3 integers)
-    threadGroupSize: ThreadGroupSize | { x: number, y: number, z: number } | undefined;
+    threadGroupSize: [number, number, number] | undefined;
 
     // resource name (string) -> binding descriptor 
     resourceBindings: Bindings | undefined;
@@ -22,7 +18,7 @@ export class ComputePipeline {
         this.device = device;
     }
 
-    setThreadGroupSize(size: ThreadGroupSize | { x: number, y: number, z: number }) {
+    setThreadGroupSize(size: [number, number, number]) {
         this.threadGroupSize = size;
     }
 
@@ -44,7 +40,7 @@ export class ComputePipeline {
         this.pipelineLayout = layout;
     }
 
-    createPipeline(shaderModule: GPUShaderModule, entryPoint: string, resources: Map<string, GPUTexture | GPUBuffer> | null) {
+    createPipeline(shaderModule: GPUShaderModule, entryPoint: string) {
         if (this.pipelineLayout == undefined)
             throw new Error("Cannot create pipeline without layout");
         const pipeline = this.device.createComputePipeline({
@@ -54,10 +50,6 @@ export class ComputePipeline {
         });
 
         this.pipeline = pipeline;
-
-        // If resources are provided, create the bind group right away
-        if (resources)
-            this.createBindGroup(resources);
     }
 
     createBindGroup(allocatedResources: Map<string, GPUObjectBase>) {

--- a/src/demo-list.ts
+++ b/src/demo-list.ts
@@ -6,6 +6,7 @@ export let demoList = [
   { name: "──────────", url: "" },
   { name: "ShaderToy: Circle", url: "circle.slang" },
   { name: "ShaderToy: Ocean", url: "ocean.slang" },
+  { name: "Painting", url: "painting.slang" },
   { name: "2D Splatter", url: "gsplat2d.slang" },
   { name: "Differentiable 2D Splatter", url: "gsplat2d-diff.slang" },
   { name: "──────────", url: "" },

--- a/src/slang/imageMain.slang
+++ b/src/slang/imageMain.slang
@@ -1,13 +1,13 @@
 import user;
 import playground;
 
-RWStructuredBuffer<int>             outputBuffer;
-
 [format("rgba8")]
+[playground::BLACK_SCREEN(1.0, 1.0)]
 WTexture2D                          outputTexture;
 
 [shader("compute")]
 [numthreads(16, 16, 1)]
+[playground::CALL::SIZE_OF("outputTexture")]
 void imageMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     uint width = 0;

--- a/src/slang/playground.slang
+++ b/src/slang/playground.slang
@@ -117,6 +117,13 @@ public struct playground_BLACKAttribute
 };
 
 [__AttributeUsage(_AttributeTargets.Var)]
+public struct playground_BLACK_SCREENAttribute
+{
+    float widthScale;
+    float heightScale;
+};
+
+[__AttributeUsage(_AttributeTargets.Var)]
 public struct playground_URLAttribute
 {
     string url;

--- a/src/slang/printMain.slang
+++ b/src/slang/printMain.slang
@@ -1,13 +1,14 @@
 import user;
 import playground;
 
-RWStructuredBuffer<int>               outputBuffer;
-
 [format("rgba8")]
+[playground::BLACK_SCREEN(1.0, 1.0)]
 WTexture2D                          outputTexture;
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
+[playground::CALL(1, 1, 1)]
+[playground::CALL::ONCE]
 void printMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     printMain();

--- a/src/util.ts
+++ b/src/util.ts
@@ -533,20 +533,8 @@ function formatSpecifier(value: string, { flags, width, precision, specifierType
 // };
 //
 
-export type HashedStringData = {
-    hash: number,
-    string: string,
-}
-
-function hashToString(hashedStrings: HashedStringData[], hash: number): string {
-    for (let i = 0; i < hashedStrings.length; i++) {
-        if (hashedStrings[i].hash == hash) {
-            return hashedStrings[i].string;
-        }
-    }
-    throw new Error("Could not find matching string hash")
-}
-export function parsePrintfBuffer(hashedStrings: HashedStringData[], printfValueResource: GPUBuffer, bufferElementSize: number) {
+export type HashedStringData = {[hash: number]: string}
+export function parsePrintfBuffer(hashedStrings: HashedStringData, printfValueResource: GPUBuffer, bufferElementSize: number) {
     // Read the printf buffer
     const printfBufferArray = new Uint32Array(printfValueResource.getMappedRange())
 
@@ -564,10 +552,10 @@ export function parsePrintfBuffer(hashedStrings: HashedStringData[], printfValue
         const type = printfBufferArray[offset];
         switch (type) {
             case 1: // format string
-                formatString = hashToString(hashedStrings, (printfBufferArray[offset + 1] << 0));  // low field
+                formatString = hashedStrings[(printfBufferArray[offset + 1] << 0)]!;  // low field
                 break;
             case 2: // normal string
-                dataArray.push(hashToString(hashedStrings, (printfBufferArray[offset + 1] << 0)));  // low field
+                dataArray.push(hashedStrings[(printfBufferArray[offset + 1] << 0)]);  // low field
                 break;
             case 3: // integer
                 dataArray.push(printfBufferArray[offset + 1]);  // low field

--- a/src/util.ts
+++ b/src/util.ts
@@ -547,7 +547,6 @@ function hashToString(hashedStrings: HashedStringData[], hash: number): string {
     throw new Error("Could not find matching string hash")
 }
 export function parsePrintfBuffer(hashedStrings: HashedStringData[], printfValueResource: GPUBuffer, bufferElementSize: number) {
-
     // Read the printf buffer
     const printfBufferArray = new Uint32Array(printfValueResource.getMappedRange())
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,6 +30,49 @@ export async function decompressFromBase64URL(base64: string) {
     return decompressed;
 }
 
+export type ScalarType = `${"uint" | "int"}${8 | 16 | 32 | 64}` | `${"float"}${16 | 32 | 64}`;
+
+export type SlangFormat = "rgba32f" | "rgba16f" | "rg32f" | "rg16f" | "r11f_g11f_b10f" | "r32f" | "r16f" | "rgba16" | "rgb10_a2" | "rgba8" | "rg16" | "rg8" | "r16" | "r8" | "rgba16_snorm" | "rgba8_snorm" | "rg16_snorm" | "rg8_snorm" | "r16_snorm" | "r8_snorm" | "rgba32i" | "rgba16i" | "rgba8i" | "rg32i" | "rg16i" | "rg8i" | "r32i" | "r16i" | "r8i" | "rgba32ui" | "rgba16ui" | "rgb10_a2ui" | "rgba8ui" | "rg32ui" | "rg16ui" | "rg8ui" | "r32ui" | "r16ui" | "r8ui" | "64ui" | "r64i" | "bgra8"
+
+type ScalarRepresentation = `8unorm` | `${16 | 32}float` | `${8 | 16 | 32}${"sint" | "uint"}`;
+function getWebGPURepresentation(scalarType: ScalarType): ScalarRepresentation {
+    let size = parseInt(scalarType.replace(/^[a-z]*/, ""));
+    let type = scalarType.replace(/[0-9]*$/, "");
+    if (type == "int")
+        type = "sint";
+
+    return `${size}${type}` as any
+}
+
+function getScalarSize(scalarType: ScalarType): 8 | 16 | 32 | 64 {
+    let size = parseInt(scalarType.replace(/^[a-z]*/, ""));
+    return size as any;
+}
+
+export function getTextureFormat(componentCount: 1 | 2 | 3 | 4, scalarType: ScalarType, access: GPUStorageTextureAccess | undefined): GPUTextureFormat {
+    if (access == "read-write" && componentCount > 1) {
+        throw new Error("There are no texture formats available with more than 1 component that are read-write")
+    }
+    let scalarSize = getScalarSize(scalarType);
+
+    if (access == "write-only" && componentCount == 2 && scalarSize != 32) {
+        throw new Error("There are no non 32 bit texture formats available with 2 components that are write-only")
+    }
+
+    if (scalarSize == 64) {
+        throw new Error("There are 64 bit texture formats available")
+    }
+
+    let scalarRepresentation = getWebGPURepresentation(scalarType);
+    if (componentCount == 1) {
+        return `r${scalarRepresentation}`
+    } else if (componentCount == 2) {
+        return `rg${scalarRepresentation}`
+    } else {
+        return `rgba${scalarRepresentation}`
+    }
+}
+
 export function sizeFromFormat(format: GPUTextureFormat) {
     switch (format) {
         case "r8unorm":
@@ -76,6 +119,56 @@ export function sizeFromFormat(format: GPUTextureFormat) {
         default:
             throw new Error(`Could not get size of unrecognized format "${format}"`)
     }
+}
+
+export const ACCESS_MAP = {
+    "readWrite": "read-write",
+    "write": "write-only",
+    "read": "read-only",
+} as const;
+
+const FORMAT_MAP: Partial<Record<SlangFormat, GPUTextureFormat>> = {
+    "rgba32f": "rgba32float",
+    "rgba16f": "rgba16float",
+    "rg32f": "rg32float",
+    "rg16f": "rg16float",
+    "r32f": "r32float",
+    "r16f": "r16float",
+    "rgb10_a2": "rgb10a2unorm",
+    "rgba8": "rgba8unorm",
+    "rg8": "rg8unorm",
+    "r8": "r8unorm",
+    "rgba8_snorm": "rgba8snorm",
+    "rg8_snorm": "rg8snorm",
+    "r8_snorm": "r8snorm",
+    "rgba32i": "rgba32sint",
+    "rgba16i": "rgba16sint",
+    "rgba8i": "rgba8sint",
+    "rg32i": "rg32sint",
+    "rg16i": "rg16sint",
+    "rg8i": "rg8sint",
+    "r32i": "r32sint",
+    "r16i": "r16sint",
+    "r8i": "r8sint",
+    "rgba32ui": "rgba32uint",
+    "rgba16ui": "rgba16uint",
+    "rgb10_a2ui": "rgb10a2uint",
+    "rgba8ui": "rgba8uint",
+    "rg32ui": "rg32uint",
+    "rg16ui": "rg16uint",
+    "rg8ui": "rg8uint",
+    "r32ui": "r32uint",
+    "r16ui": "r16uint",
+    "r8ui": "r8uint",
+    "bgra8": "bgra8unorm"
+}
+
+export function webgpuFormatfromSlangFormat(format: SlangFormat): GPUTextureFormat {
+    let gpuFormat = FORMAT_MAP[format];
+    if (gpuFormat == undefined) {
+        throw new Error(`Could not find webgpu format for ${format}`);
+    }
+    return gpuFormat;
 }
 
 function reinterpretUint32AsFloat(uint32: number) {
@@ -145,6 +238,7 @@ export type ParsedCommand = {
 } | {
     "type": "URL",
     "url": string,
+    "format": GPUTextureFormat,
 } | {
     "type": "SLIDER",
     "default": number,
@@ -218,9 +312,40 @@ export function getResourceCommandsFromAttributes(reflection: ReflectionJSON): R
                 if (parameter.type.kind != "resource" || parameter.type.baseShape != "texture2D") {
                     throw new Error(`${playground_attribute_name} attribute cannot be applied to ${parameter.name}, it only supports 2D textures`)
                 }
+                let slangAccess: keyof typeof ACCESS_MAP = parameter.type.access || "read";
+                let access = ACCESS_MAP[slangAccess];
+
+                let scalarType: ScalarType;
+                let componentCount: 1 | 2 | 3 | 4;
+                if (parameter.type.resultType.kind == "scalar") {
+                    componentCount = 1;
+                    scalarType = parameter.type.resultType.scalarType;
+                } else if (parameter.type.resultType.kind == "vector") {
+                    componentCount = parameter.type.resultType.elementCount;
+                    if (parameter.type.resultType.elementType.kind != "scalar") throw new Error(`Unhandled inner type for ${name}`)
+                    scalarType = parameter.type.resultType.elementType.scalarType;
+                } else {
+                    throw new Error(`Unhandled inner type for ${name}`)
+                }
+
+                let format: GPUTextureFormat;
+                if (parameter.format) {
+                    format = webgpuFormatfromSlangFormat(parameter.format);
+                } else {
+                    try {
+                        format = getTextureFormat(componentCount, scalarType, access);
+                    } catch (e) {
+                        if (e instanceof Error)
+                            throw new Error(`Could not get texture format for ${name}: ${e.message}`)
+                        else
+                            throw new Error(`Could not get texture format for ${name}`)
+                    }
+                }
+
                 command = {
                     type: playground_attribute_name,
                     url: attribute.arguments[0] as string,
+                    format,
                 };
             } else if (playground_attribute_name == "TIME") {
                 if (parameter.type.kind != "scalar" || !parameter.type.scalarType.startsWith("float") || parameter.binding.kind != "uniform") {

--- a/src/util.ts
+++ b/src/util.ts
@@ -68,6 +68,7 @@ export function sizeFromFormat(format: GPUTextureFormat) {
         case "rgba16uint":
         case "rgba16sint":
         case "rgba16float":
+            return 8;
         case "rgba32uint": 
         case "rgba32sint": 
         case "rgba32float":

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,18 +30,46 @@ export async function decompressFromBase64URL(base64: string) {
     return decompressed;
 }
 
-export function createOutputTexture(device: GPUDevice, width: number, height: number, format: GPUTextureFormat) {
-    const textureDesc = {
-        label: 'output storage texture',
-        size: { width: width, height: height },
-        format: format,
-        usage: GPUTextureUsage.COPY_SRC |
-            GPUTextureUsage.STORAGE_BINDING |
-            GPUTextureUsage.TEXTURE_BINDING,
-    };
-
-    let storageTexture = device.createTexture(textureDesc);
-    return storageTexture;
+export function sizeFromFormat(format: GPUTextureFormat) {
+    if (format === "r8unorm") return 1;
+    else if (format === "r8snorm") return 1;
+    else if (format === "r8uint") return 1;
+    else if (format === "r8sint") return 1;
+    else if (format === "r16uint") return 2;
+    else if (format === "r16sint") return 2;
+    else if (format === "r16float") return 2;
+    else if (format === "rg8unorm") return 2;
+    else if (format === "rg8snorm") return 2;
+    else if (format === "rg8uint") return 2;
+    else if (format === "rg8sint") return 2;
+    else if (format === "r32uint") return 4;
+    else if (format === "r32sint") return 4;
+    else if (format === "r32float") return 4;
+    else if (format === "rg16uint") return 4;
+    else if (format === "rg16sint") return 4;
+    else if (format === "rg16float") return 4;
+    else if (format === "rgba8unorm") return 4;
+    else if (format === "rgba8unorm-srgb") return 4;
+    else if (format === "rgba8snorm") return 4;
+    else if (format === "rgba8uint") return 4;
+    else if (format === "rgba8sint") return 4;
+    else if (format === "bgra8unorm") return 4;
+    else if (format === "bgra8unorm-srgb") return 4;
+    else if (format === "rgb10a2unorm") return 4;
+    else if (format === "rg11b10ufloat") return 4;
+    else if (format === "rgb9e5ufloat") return 4;
+    else if (format === "rg32uint") return 8;
+    else if (format === "rg32sint") return 8;
+    else if (format === "rg32float") return 8;
+    else if (format === "rgba16uint") return 8;
+    else if (format === "rgba16sint") return 8;
+    else if (format === "rgba16float") return 8;
+    else if (format === "rgba32uint") return 16;
+    else if (format === "rgba32sint") return 16;
+    else if (format === "rgba32float") return 16;
+    else {
+        throw new Error("Unrecognized format")
+    }
 }
 
 function reinterpretUint32AsFloat(uint32: number) {
@@ -105,6 +133,10 @@ export type ParsedCommand = {
     "width": number,
     "height": number,
 } | {
+    "type": "BLACK_SCREEN",
+    "width_scale": number,
+    "height_scale": number,
+} | {
     "type": "URL",
     "url": string,
 } | {
@@ -160,6 +192,15 @@ export function getResourceCommandsFromAttributes(reflection: ReflectionJSON): R
                     type: playground_attribute_name,
                     width: attribute.arguments[0] as number,
                     height: attribute.arguments[1] as number,
+                };
+            } else if (playground_attribute_name == "BLACK_SCREEN") {
+                if (parameter.type.kind != "resource" || parameter.type.baseShape != "texture2D") {
+                    throw new Error(`${playground_attribute_name} attribute cannot be applied to ${parameter.name}, it only supports 2D textures`)
+                }
+                command = {
+                    type: playground_attribute_name,
+                    width_scale: attribute.arguments[0] as number,
+                    height_scale: attribute.arguments[1] as number,
                 };
             } else if (playground_attribute_name == "URL") {
                 if (parameter.type.kind != "resource" || parameter.type.baseShape != "texture2D") {
@@ -405,8 +446,8 @@ function formatSpecifier(value: string, { flags, width, precision, specifierType
     switch (specifierType) {
         case 'd':
         case 'i': // Integer (decimal)
-            if(typeof value !== "number") throw new Error("Invalid state");
-            
+            if (typeof value !== "number") throw new Error("Invalid state");
+
             let valueAsSignedInteger = value | 0;
             formattedValue = valueAsSignedInteger.toString();
             break;

--- a/src/util.ts
+++ b/src/util.ts
@@ -31,44 +31,49 @@ export async function decompressFromBase64URL(base64: string) {
 }
 
 export function sizeFromFormat(format: GPUTextureFormat) {
-    if (format === "r8unorm") return 1;
-    else if (format === "r8snorm") return 1;
-    else if (format === "r8uint") return 1;
-    else if (format === "r8sint") return 1;
-    else if (format === "r16uint") return 2;
-    else if (format === "r16sint") return 2;
-    else if (format === "r16float") return 2;
-    else if (format === "rg8unorm") return 2;
-    else if (format === "rg8snorm") return 2;
-    else if (format === "rg8uint") return 2;
-    else if (format === "rg8sint") return 2;
-    else if (format === "r32uint") return 4;
-    else if (format === "r32sint") return 4;
-    else if (format === "r32float") return 4;
-    else if (format === "rg16uint") return 4;
-    else if (format === "rg16sint") return 4;
-    else if (format === "rg16float") return 4;
-    else if (format === "rgba8unorm") return 4;
-    else if (format === "rgba8unorm-srgb") return 4;
-    else if (format === "rgba8snorm") return 4;
-    else if (format === "rgba8uint") return 4;
-    else if (format === "rgba8sint") return 4;
-    else if (format === "bgra8unorm") return 4;
-    else if (format === "bgra8unorm-srgb") return 4;
-    else if (format === "rgb10a2unorm") return 4;
-    else if (format === "rg11b10ufloat") return 4;
-    else if (format === "rgb9e5ufloat") return 4;
-    else if (format === "rg32uint") return 8;
-    else if (format === "rg32sint") return 8;
-    else if (format === "rg32float") return 8;
-    else if (format === "rgba16uint") return 8;
-    else if (format === "rgba16sint") return 8;
-    else if (format === "rgba16float") return 8;
-    else if (format === "rgba32uint") return 16;
-    else if (format === "rgba32sint") return 16;
-    else if (format === "rgba32float") return 16;
-    else {
-        throw new Error("Unrecognized format")
+    switch (format) {
+        case "r8unorm":
+        case "r8snorm":
+        case "r8uint":
+        case "r8sint":
+            return 1;
+        case "r16uint":
+        case "r16sint":
+        case "r16float":
+        case "rg8unorm":
+        case "rg8snorm":
+        case "rg8uint":
+        case "rg8sint":
+            return 2;
+        case "r32uint":
+        case "r32sint":
+        case "r32float":
+        case "rg16uint":
+        case "rg16sint":
+        case "rg16float":
+        case "rgba8unorm":
+        case "rgba8unorm-srgb":
+        case "rgba8snorm":
+        case "rgba8uint":
+        case "rgba8sint":
+        case "bgra8unorm":
+        case "bgra8unorm-srgb":
+        case "rgb10a2unorm":
+        case "rg11b10ufloat":
+        case "rgb9e5ufloat":
+            return 4;
+        case "rg32uint":
+        case "rg32sint":
+        case "rg32float":
+        case "rgba16uint":
+        case "rgba16sint":
+        case "rgba16float":
+        case "rgba32uint": 
+        case "rgba32sint": 
+        case "rgba32float":
+            return 16;
+        default:
+            throw new Error(`Could not get size of unrecognized format "${format}"`)
     }
 }
 
@@ -533,7 +538,7 @@ function formatSpecifier(value: string, { flags, width, precision, specifierType
 // };
 //
 
-export type HashedStringData = {[hash: number]: string}
+export type HashedStringData = { [hash: number]: string }
 export function parsePrintfBuffer(hashedStrings: HashedStringData, printfValueResource: GPUBuffer, bufferElementSize: number) {
     // Read the printf buffer
     const printfBufferArray = new Uint32Array(printfValueResource.getMappedRange())


### PR DESCRIPTION
closes #123
closes #119 
closes #118
Since the screen size can now be got through measuring the size of a BLACK_SCREEN texture I'm also marking this as
closes #84

This also includes a number of derivative changes for code quality:
* `outputBuffer` removed from `imageMain.slang` and `printMain.slang`. It wasn't being used.
* `outputTexture` size now controlled from `BLACK_SCREEN`
* `imageMain` and `printMain` are now called via attributes
* removed `computePipeline` as it was no longer necessary due to main entrypoints being called from attributes

Deploy: https://devon7925.github.io/slang-playground/