### PR TITLE
Sample texture in compute shader (playground)

### DIFF
--- a/public/demos/image-from-url.slang
+++ b/public/demos/image-from-url.slang
@@ -14,6 +14,6 @@ float4 imageMain(uint2 dispatchThreadID, int2 screenSize)
     float2 scaled = float2(dispatchThreadID.xy) / screenSize.y;
     float2 flipped = float2(scaled.x, 1 - scaled.y);
 
-    float4 imageColor = myImage.SampleLevel(sampler, flipped, 0, int2(0));
+    float4 imageColor = myImage.SampleLevel(sampler, flipped, 0);
     return imageColor;
 }

--- a/public/demos/image-from-url.slang
+++ b/public/demos/image-from-url.slang
@@ -6,15 +6,14 @@ import playground;
 [format("rgba8")]
 Texture2D<float4> myImage;
 
+[playground::SAMPLER]
+SamplerState sampler;
+
 float4 imageMain(uint2 dispatchThreadID, int2 screenSize)
 {
-    uint imageW;
-    uint imageH;
-    myImage.GetDimensions(imageW, imageH);
+    float2 scaled = float2(dispatchThreadID.xy) / screenSize.y;
+    float2 flipped = float2(scaled.x, 1 - scaled.y);
 
-    uint2 scaled = (uint2)floor(float2(dispatchThreadID.xy) / screenSize.y * float2(imageW, imageH));
-    uint2 flipped = uint2(scaled.x, imageH - scaled.y);
-
-    float4 imageColor = myImage[flipped];
+    float4 imageColor = myImage.SampleLevel(sampler, flipped, 0, int2(0));
     return imageColor;
 }

--- a/slang-wasm-build.sh
+++ b/slang-wasm-build.sh
@@ -45,7 +45,7 @@ echo "if(EMSCRIPTEN)
         --emit-tsd \"$<TARGET_FILE_DIR:slang-wasm>/slang-wasm.d.ts\"
         -sMODULARIZE=1
         -sEXPORT_ES6=1
-        -sEXTRA_EXPORTED_RUNTIME_METHODS=['FS']
+        -sEXPORTED_RUNTIME_METHODS=['FS']
     )
 endif()" > "source/slang-wasm/CMakeLists.txt"
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -50,6 +50,8 @@ export type ReflectionType = {
     "baseShape": "texture2D",
     "access"?: "readWrite" | "write",
     "resultType": ReflectionType,
+} | {
+    "kind": "samplerState",
 };
 
 export type ReflectionParameter = {
@@ -394,6 +396,8 @@ export class SlangCompiler {
                 console.error(`Could not generate binding for ${name}`)
                 return {}
             }
+        } else if (parameterReflection.type.kind == "samplerState") {
+            return { sampler: {} };
         } else if (parameterReflection.binding.kind == "uniform") {
             return { buffer: { type: 'uniform' } };
         } else {

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -56,6 +56,8 @@ defineExpose({
         Initialize a <code>float</code> texture with zeros of the provided size.
         <h4 class="doc-header"><code>[playground::BLACK_SCREEN(1.0, 1.0)]</code></h4>
         Initialize a <code>float</code> texture with zeros with a size proportional to the screen size.
+        <h4 class="doc-header"><code>[playground::SAMPLER]</code></h4>
+        Initialize a sampler state with linear filtering and repeat address mode for sampling textures.
         <h4 class="doc-header"><code>[playground::URL("https://example.com/image.png")]</code></h4>
         Initialize a texture with image from URL.
         <h4 class="doc-header"><code>[playground::RAND(1000)]</code></h4>

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -75,6 +75,12 @@ export class ComputePipeline {
                     }
                     entries.push({ binding: bindInfo.binding, resource: resource.createView() });
                 }
+                else if (bindInfo.sampler) {
+                    if (!(resource instanceof GPUSampler)) {
+                        throw new Error("Invalid state");
+                    }
+                    entries.push({ binding: bindInfo.binding, resource: resource });
+                }
                 else if (bindInfo.texture) {
                     if (!(resource instanceof GPUTexture)) {
                         throw new Error("Invalid state");

--- a/src/slang/playground.slang
+++ b/src/slang/playground.slang
@@ -1,4 +1,4 @@
-// type field: 1 for format string, 2 for normal string, 3 for integer, 4 for float, 5 for double, 
+// type field: 1 for format string, 2 for normal string, 3 for integer, 4 for float, 5 for double,
 struct FormattedStruct
 {
     uint32_t type = 0xFFFFFFFF;
@@ -111,6 +111,12 @@ public struct playground_URLAttribute
     string url;
 };
 
+// Bind a sampler with reasonable defaults for texture sampling.
+[__AttributeUsage(_AttributeTargets.Var)]
+public struct playground_SAMPLERAttribute
+{
+};
+
 // Initialize a \`float\` buffer with uniform random floats between 0 and 1.
 [__AttributeUsage(_AttributeTargets.Var)]
 public struct playground_RANDAttribute
@@ -121,7 +127,8 @@ public struct playground_RANDAttribute
 // Gives the current time in milliseconds.
 [__AttributeUsage(_AttributeTargets.Var)]
 public struct playground_TIMEAttribute
-{};
+{
+};
 
 // Gives mouse position info.
 // \`xy\`: mouse position (in pixels) during last button down.
@@ -130,7 +137,8 @@ public struct playground_TIMEAttribute
 // \`sign(mouze.w)\`: button is clicked
 [__AttributeUsage(_AttributeTargets.Var)]
 public struct playground_MOUSE_POSITIONAttribute
-{};
+{
+};
 
 // Control a \`float\` uniform with a provided default, minimum, and maximum.
 [__AttributeUsage(_AttributeTargets.Var)]

--- a/src/util.ts
+++ b/src/util.ts
@@ -185,7 +185,7 @@ function roundUpToNearest(x: number, nearest: number) {
 }
 
 function getSize(reflectionType: ReflectionType): number {
-    if (reflectionType.kind == "resource") {
+    if (reflectionType.kind == "resource" || reflectionType.kind == "samplerState") {
         throw new Error("unimplemented");
     } else if (reflectionType.kind == "scalar") {
         const bitsMatch = reflectionType.scalarType.match(/\d+$/);

--- a/src/util.ts
+++ b/src/util.ts
@@ -112,8 +112,8 @@ export function sizeFromFormat(format: GPUTextureFormat) {
         case "rgba16sint":
         case "rgba16float":
             return 8;
-        case "rgba32uint": 
-        case "rgba32sint": 
+        case "rgba32uint":
+        case "rgba32sint":
         case "rgba32float":
             return 16;
         default:
@@ -257,7 +257,9 @@ export type ParsedCommand = {
 } | {
     "type": "MOUSE_POSITION",
     "offset": number,
-}
+} | {
+    "type": "SAMPLER"
+};
 export type ResourceCommand = { resourceName: string; parsedCommand: ParsedCommand; };
 export function getResourceCommandsFromAttributes(reflection: ReflectionJSON): ResourceCommand[] {
     let commands: { resourceName: string, parsedCommand: ParsedCommand }[] = [];
@@ -278,6 +280,13 @@ export function getResourceCommandsFromAttributes(reflection: ReflectionJSON): R
                     type: playground_attribute_name,
                     count: attribute.arguments[0] as number,
                     elementSize: getSize(parameter.type.resultType),
+                };
+            } else if (playground_attribute_name == "SAMPLER") {
+                if (parameter.type.kind != "samplerState") {
+                    throw new Error(`${playground_attribute_name} attribute cannot be applied to ${parameter.name}, it only supports samplers`);
+                }
+                command = {
+                    type: playground_attribute_name
                 };
             } else if (playground_attribute_name == "RAND") {
                 if (parameter.type.kind != "resource" || parameter.type.baseShape != "structuredBuffer") {


### PR DESCRIPTION
fixes #125
This adds `[playground::SAMPLER]` to allow using samplers in the playground. It also fixes CI which was broken by the latest emscripten release(4.0.6).

Deploy: https://devon7925.github.io/slang-playground/