### PR TITLE
Add Play/Pause, Reset, Step Fwd / Bwd and Fullscreen to UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
   <link rel="shortcut icon" href="/images/favicon.ico" />
   <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png" />
   <link href="src/assets/styles.css" rel="stylesheet" />
-  <link rel="stylesheet" href="jsontree/jsontree.js.css">
-  <script src="jsontree/jsontree.min.js"></script>
+  <link rel="stylesheet" href="/jsontree/jsontree.js.css">
+  <script type="module" src="/jsontree/jsontree.min.js"></script>
   <script type="module" src="src/main.ts"></script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TMTZVLLMBP"></script>
   <script>

--- a/public/demos/circle.slang
+++ b/public/demos/circle.slang
@@ -7,6 +7,9 @@ import playground;
 [playground::TIME]
 uniform float time;
 
+[playground::FRAME_ID]
+uniform float frame;
+
 typealias vec2 = float2;
 typealias vec3 = float3;
 typealias vec4 = float4;
@@ -45,7 +48,7 @@ float4 imageMain(uint2 dispatchThreadID, int2 screenSize)
 	// draw color beam
 	uv = (2.0 * uv) - 1.0;
 	float beamWidth = (0.7 + 
-        0.5 * cos(uv.x * 10.0 * tau * 0.15 * clamp(floor(5.0 + 10.0 * cos(time)), 0.0, 10.0)))
+        0.5 * cos(uv.x * 10.0 * tau * 0.15 * clamp(floor(5.0 + 10.0 * cos(time/60.f)), 0.0, 10.0)))
         * abs(1.0 / (30.0 * uv.y));
 	vec3 horBeam = vec3(beamWidth);
 	return vec4(((horBeam) * horColour), 1.0);

--- a/src/App.vue
+++ b/src/App.vue
@@ -564,7 +564,6 @@ function logError(message: string) {
                         :title="device == null ? `Run shader feature is disabled because the current browser does not support WebGPU.` : `(F5) Compile and run the shader that provides either 'printMain' or 'imageMain'.);`"
                         @click="doRun()">&#9658;
                         Run</button>
-
                 </div>
 
                 <!-- Entry/Compile section -->

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,7 +54,7 @@ const shareButton = useTemplateRef("shareButton");
 const tooltip = useTemplateRef("tooltip");
 const helpModal = useTemplateRef("helpModal");
 const targetSelect = useTemplateRef("targetSelect");
-const renderCanvas = useTemplateRef("renderCanvas");
+const renderCanvas = useTemplateRef<InstanceType<typeof RenderCanvas>>("renderCanvas");
 
 const selectedDemo = ref("");
 const initialized = ref(false);
@@ -115,7 +115,7 @@ onBeforeMount(async () => {
 });
 
 function updateProfileOptions() {
-    const selectedTarget = targetSelect.value!.getValue();
+    const selectedTarget = targetSelect.value!.getValue() as typeof compileTargets[number];
 
     // If the selected target does not have any profiles, hide the profile dropdown.
     const profileData = targetProfileMap[selectedTarget] || null;
@@ -274,10 +274,10 @@ function tryTogglePause() {
     renderCanvas.value!.pauseRender = !renderCanvas.value!.pauseRender;
 }
 
-const frameID = computed(() => renderCanvas.value?.frameID ?? 0);
-const fps = computed(() => renderCanvas.value?.fps ?? 0);
-const canvasWidth = computed(() => renderCanvas.value?.canvasWidth ?? 0);
-const canvasHeight = computed(() => renderCanvas.value?.canvasHeight ?? 0);
+const frameID = computed<number>(() => renderCanvas.value?.frameID ?? 0);
+const fps = computed<number>(() => renderCanvas.value?.fps ?? 0);
+const canvasWidth = computed<number>(() => renderCanvas.value?.canvasWidth ?? 0);
+const canvasHeight = computed<number>(() => renderCanvas.value?.canvasHeight ?? 0);
 
 function resetFrame() {
     if (renderCanvas.value) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -274,6 +274,41 @@ function tryTogglePause() {
     renderCanvas.value!.pauseRender = !renderCanvas.value!.pauseRender;
 }
 
+const frameID = computed(() => renderCanvas.value?.frameID ?? 0);
+const fps = computed(() => renderCanvas.value?.fps ?? 0);
+const canvasWidth = computed(() => renderCanvas.value?.canvasWidth ?? 0);
+const canvasHeight = computed(() => renderCanvas.value?.canvasHeight ?? 0);
+
+function resetFrame() {
+    if (renderCanvas.value) {
+        renderCanvas.value.setFrame(0);
+        isPaused.value = true;
+    }
+}
+
+function nextFrame() {
+    if (renderCanvas.value) {
+        renderCanvas.value.setFrame(frameID.value + 1);
+        isPaused.value = true;
+    }
+}
+function prevFrame() {
+    if (renderCanvas.value) {
+        renderCanvas.value.setFrame(frameID.value - 1);
+        isPaused.value = true;
+    }
+}
+
+function toggleFullscreen() {
+    const container = document.getElementById('renderOutput');
+    if (!container) return;
+    if (!document.fullscreenElement) {
+        container.requestFullscreen();
+    } else if (document.exitFullscreen) {
+        document.exitFullscreen();
+    }
+}
+
 function tryRun() {
     smallScreenEditorVisible.value = false;
 
@@ -530,11 +565,6 @@ function logError(message: string) {
                         @click="doRun()">&#9658;
                         Run</button>
 
-                    <button :disabled="device == null"
-                        title="Pause or resume the shader's animation loop"
-                        @click="togglePause()">
-                        {{ isPaused ? '&#9654' + ' Resume' : '&#9208' + ' Pause' }}
-                    </button>
                 </div>
 
                 <!-- Entry/Compile section -->
@@ -597,6 +627,20 @@ function logError(message: string) {
             <div id="renderOutput" v-show="currentDisplayMode == 'imageMain'">
                 <RenderCanvas :device="device" @log-error="logError" @log-output="(log) => { printedText = log }"
                     ref="renderCanvas"></RenderCanvas>
+                <div class="control-bar">
+                    <div class="controls-left">
+                        <button @click="resetFrame" title="Reset frame to 0">&#x23EE;</button>
+                        <button @click="prevFrame" title="Step backward">&#x23F4;</button>
+                        <button @click="nextFrame" title="Step forward">&#x23F5;</button>
+                        <button @click="togglePause" :title="isPaused ? 'Resume' : 'Pause'">⏯</button>
+                        <span class="frame-counter">Frame: {{ frameID }}</span>
+                        <span class="fps-counter">FPS: {{ fps }}</span>
+                        <span class="resolution">Resolution: {{ canvasWidth }}x{{ canvasHeight }}</span>
+                    </div>
+                    <div class="controls-right">
+                        <button @click="toggleFullscreen" title="Toggle full screen">&#x26F6;</button>
+                    </div>
+                </div>
             </div>
             <textarea readonly class="printSpace outputSpace"
                 v-show="currentDisplayMode == 'printMain'">{{ printedText }}</textarea>
@@ -700,5 +744,36 @@ function logError(message: string) {
     background-color: var(--code-editor-background);
     height: 100%;
     overflow-y: scroll;
+}
+
+.control-bar {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 32px;
+    padding: 4px 8px;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: white;
+    font-size: 14px;
+}
+.control-bar .controls-left > * {
+    margin-right: 8px;
+}
+.control-bar .controls-right > * {
+    margin-left: 8px;
+}
+.control-bar button {
+    background: none;
+    border: none;
+    color: white;
+    cursor: pointer;
+}
+.control-bar button:disabled {
+    cursor: default;
+    opacity: 0.5;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -256,6 +256,24 @@ function doRun() {
     }
 }
 
+const isPaused = ref(false);
+function togglePause() {
+    try {
+        tryTogglePause();
+        isPaused.value = !isPaused.value;
+    } catch (e: any) {
+        diagnosticsText.value = e.message;
+    }
+}
+
+function tryTogglePause() {
+    if (!renderCanvas.value) {
+        throw new Error("WebGPU is not supported in this browser");
+    }
+
+    renderCanvas.value!.pauseRender = !renderCanvas.value!.pauseRender;
+}
+
 function tryRun() {
     smallScreenEditorVisible.value = false;
 
@@ -511,6 +529,12 @@ function logError(message: string) {
                         :title="device == null ? `Run shader feature is disabled because the current browser does not support WebGPU.` : `(F5) Compile and run the shader that provides either 'printMain' or 'imageMain'.);`"
                         @click="doRun()">&#9658;
                         Run</button>
+
+                    <button :disabled="device == null"
+                        title="Pause or resume the shader's animation loop"
+                        @click="togglePause()">
+                        {{ isPaused ? '&#9654' + ' Resume' : '&#9208' + ' Pause' }}
+                    </button>
                 </div>
 
                 <!-- Entry/Compile section -->

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -236,6 +236,13 @@ button:disabled:hover {
   align-items: center;
 }
 
+.navbar-run > button {
+  width: 100px;
+  height: 100%;
+  box-sizing: border-box;
+  text-align: center;
+}
+
 .navbar-compile {
   flex-basis: 50%;
   display: flex;

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -64,6 +64,8 @@ defineExpose({
         Initialize a <code>float</code> buffer with uniform random floats between 0 and 1.
         <h4 class="doc-header"><code>[playground::TIME]</code></h4>
         Gives a <code>float</code> uniform the current time in milliseconds.
+        <h4 class="doc-header"><code>[playground::FRAME_ID]</code></h4>
+        Gives a <code>float</code> uniform the current frame index (starting from 0).
         <h4 class="doc-header"><code>[playground::MOUSE_POSITION]</code></h4>
         Gives a <code>float4</code> uniform mouse data.
         <ul>

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -19,6 +19,7 @@ let randFloatResources: Map<string, GPUObjectBase>;
 
 let renderThread: Promise<void> | null = null;
 let abortRender = false;
+const pauseRender = ref(false);
 let onRenderAborted: (() => void) | null = null;
 
 const printfBufferElementSize = 12;
@@ -47,6 +48,7 @@ let emit = defineEmits<{
 
 defineExpose({
     onRun,
+    pauseRender
 });
 
 onMounted(() => {
@@ -873,11 +875,13 @@ function onRun(runCompiledCode: CompiledPlayground) {
             if (compiler == null) {
                 throw new Error("Could not get compiler");
             }
-            if (compiler.shaderType !== null && !abortRender) {
+            if (compiler.shaderType !== null && !abortRender && !pauseRender.value) {
                 const keepRendering = await execFrame(timeMS, compiler?.shaderType || null, compiledCode, firstFrame);
                 firstFrame = false;
                 return keepRendering;
             }
+            if (!abortRender) return true;
+            
             return false;
         });
 }

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -56,7 +56,6 @@ defineExpose({
     fps,
     canvasWidth: computed(() => canvas.value?.width ?? 0),
     canvasHeight: computed(() => canvas.value?.height ?? 0),
-    stepFrame,
     setFrame,
 });
 
@@ -80,16 +79,6 @@ onMounted(() => {
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
 })
-
-/**
- * Step the render by exactly one frame, optionally reset to frame 0 first.
- */
-/**
- * Step the render by exactly one frame, optionally resetting to frame 0 first.
- */
-function stepFrame(reset = false) {
-    setFrame(reset ? 0 : frameID.value + 1);
-}
 
 /**
  * Go to the specified frame index and render exactly that frame.

--- a/src/components/RenderCanvas.vue
+++ b/src/components/RenderCanvas.vue
@@ -5,7 +5,7 @@ import { ComputePipeline } from '../compute';
 import { GraphicsPipeline, passThroughshaderCode } from '../pass_through';
 import { compiler } from '../try-slang';
 import { type CallCommand, NotReadyError, parsePrintfBuffer, type ResourceCommand, sizeFromFormat } from '../util';
-import { onMounted, ref, computed, useTemplateRef } from 'vue';
+import { onMounted, ref, useTemplateRef } from 'vue';
 import randFloatShaderCode from "../slang/rand_float.slang?raw";
 
 let context: GPUCanvasContext;
@@ -35,6 +35,8 @@ let canvasMouseClicked = false;
 const pressedKeys = new Set<string>();
 
 const canvas = useTemplateRef("canvas");
+const canvasWidth = ref(0);
+const canvasHeight = ref(0);
 const frameTime = ref(0);
 const frameID = ref(0);
 const fps = ref(0);
@@ -54,8 +56,8 @@ defineExpose({
     frameTime,
     frameID,
     fps,
-    canvasWidth: computed(() => canvas.value?.width ?? 0),
-    canvasHeight: computed(() => canvas.value?.height ?? 0),
+    canvasWidth,
+    canvasHeight,
     setFrame,
 });
 
@@ -78,6 +80,12 @@ onMounted(() => {
 
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
+
+    // initialize reported canvas size
+    if (canvas.value) {
+        canvasWidth.value = canvas.value.width;
+        canvasHeight.value = canvas.value.height;
+    }
 })
 
 /**
@@ -278,6 +286,10 @@ function resizeCanvasHandler(entries: ResizeObserverEntry[]) {
     let needResize = resizeCanvas(entries);
     if (needResize) {
         handleResize();
+        if (canvas.value) {
+            canvasWidth.value = canvas.value.width;
+            canvasHeight.value = canvas.value.height;
+        }
     }
 }
 

--- a/src/slang/playground.slang
+++ b/src/slang/playground.slang
@@ -130,6 +130,12 @@ public struct playground_TIMEAttribute
 {
 };
 
+// Gives the current shader playback frame index.
+[__AttributeUsage(_AttributeTargets.Var)]
+public struct playground_FRAME_IDAttribute
+{
+};
+
 // Gives mouse position info.
 // \`xy\`: mouse position (in pixels) during last button down.
 // \`abs(zw)\`: mouse position during last button click.

--- a/src/util.ts
+++ b/src/util.ts
@@ -255,6 +255,9 @@ export type ParsedCommand = {
     "type": "TIME",
     "offset": number,
 } | {
+    "type": "FRAME_ID",
+    "offset": number,
+} | {
     "type": "MOUSE_POSITION",
     "offset": number,
 } | {
@@ -369,6 +372,14 @@ export function getResourceCommandsFromAttributes(reflection: ReflectionJSON): R
                     type: playground_attribute_name,
                     offset: parameter.binding.offset,
                 };
+            } else if (playground_attribute_name == "FRAME_ID") {
+                if (parameter.type.kind != "scalar" || !parameter.type.scalarType.startsWith("float") || parameter.binding.kind != "uniform") {
+                    throw new Error(`${playground_attribute_name} attribute cannot be applied to ${parameter.name}, it only supports floats`)
+                }
+                command = {
+                    type: playground_attribute_name,
+                    offset: parameter.binding.offset,
+                };
             } else if (playground_attribute_name == "MOUSE_POSITION") {
                 if (parameter.type.kind != "vector" || parameter.type.elementCount <= 3 || parameter.type.elementType.kind != "scalar" || !parameter.type.elementType.scalarType.startsWith("float") || parameter.binding.kind != "uniform") {
                     throw new Error(`${playground_attribute_name} attribute cannot be applied to ${parameter.name}, it only supports float vectors`)
@@ -451,6 +462,8 @@ export type UniformController = { buffer_offset: number } & ({
 } | {
     type: "TIME",
 } | {
+    type: "FRAME_ID",
+} | {
     type: "MOUSE_POSITION",
 } | {
     type: "KEY",
@@ -482,6 +495,11 @@ export function getUniformControllers(resourceCommands: ResourceCommand[]): Unif
                 value: resourceCommand.parsedCommand.default,
             })
         } else if (resourceCommand.parsedCommand.type == 'TIME') {
+            controllers.push({
+                type: resourceCommand.parsedCommand.type,
+                buffer_offset: resourceCommand.parsedCommand.offset,
+            })
+        } else if (resourceCommand.parsedCommand.type == 'FRAME_ID') {
             controllers.push({
                 type: resourceCommand.parsedCommand.type,
                 buffer_offset: resourceCommand.parsedCommand.offset,


### PR DESCRIPTION
This change adds a little bar below the render canvas, which gives a couple useful buttons to control the shader. This change also exposes a "FRAME_ID" to the shader as a uniform, which is a zero-indexed value which increments between rendered frames. Should be able to play with it here: https://natevm.github.io/slang-playground/

<img width="915" alt="image" src="https://github.com/user-attachments/assets/4ebd0fc1-0e0d-4fc2-b5c1-3caecc4101d9" />

On the bottom, from left to right, 
1. Reset - sets the frameID back to 0. If paused, renders that single frame. 
2. Step Backward - decrements the frameID by one, then renders a single frame
3. Step Forward - increments the frameID by one, then renders a single frame
4. Pause/Resume - Causes the renderer to temporarily halt rendering frames, and otherwise continues playback.

The above features are really useful for debugging shaders. It's often the case that a shader regression might make the render loop very slow, causing the entire browser screen to lock up. By clicking the pause button, the browser interface will become unlocked, letting users fix the regression. The reset/step mechanic also gives users a way to reproduce frames as they're working through an algorithm. (For eg, if I'm working on some new SDF function and I see some artifact blink in our out at a given frame, I can pause, then step backwards until I have the reproducing frame pinned down.)

Full screen is mostly a nice-to-have, but can be a useful tool for screen captures. 
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/fe62a2ce-6db5-439c-b168-c39feb5f93fa" />
