### PR TITLE
Add `common.slang` tab to UI to help cleanup main entry points

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -599,7 +599,7 @@ function logError(message: string) {
         <Teleport v-if="pageLoaded" defer :to="isSmallScreen ? '#small-screen-code-gen' : '.codeGenSpace'">
             <TabContainer ref="tabContainer">
                 <Tab name="code" label="Target Code">
-                    <MonacoEditor ref="codeGenArea" readOnlyMode />
+                    <MonacoEditor ref="codeGenArea" readOnlyMode modelUri="generated.slang" />
                 </Tab>
 
                 <Tab name="reflection" label="Reflection">

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -109,6 +109,7 @@ export class SlangCompiler {
 
         module.FS.createDataFile("/", "user.slang", new DataView(new ArrayBuffer(0)), true, true, false);
         module.FS.createDataFile("/", "playground.slang", new DataView(new ArrayBuffer(0)), true, true, false);
+        module.FS.createDataFile("/", "common.slang", new DataView(new ArrayBuffer(0)), true, true, false);
     }
 
     init() {

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -11,6 +11,7 @@ import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
 
 export const userCodeURI = "file:///user.slang";
+export const commonCodeURI = "file:///common.slang";
 const playgroundCodeURI = "file:///playground.slang";
 let languageRegistered = false;
 export function initMonaco() {
@@ -858,6 +859,7 @@ export function initLanguageServer() {
         throw new Error("Slang is undefined!");
     }
     slangd.didOpenTextDocument(userCodeURI, "");
+    slangd.didOpenTextDocument(commonCodeURI, "");
     slangd.didOpenTextDocument(playgroundCodeURI, playgroundSource);
 }
 

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -511,7 +511,7 @@ export function initMonaco() {
             if (slangd == null) {
                 return null;
             }
-            let result = slangd.hover(userCodeURI, { line: position.lineNumber - 1, character: position.column - 1 });
+            let result = slangd.hover(model.uri.toString(), { line: position.lineNumber - 1, character: position.column - 1 });
             if (result == null) {
                 return null;
             }
@@ -531,7 +531,7 @@ export function initMonaco() {
             if (slangd == null) {
                 return null;
             }
-            let result = slangd.gotoDefinition(userCodeURI, { line: position.lineNumber - 1, character: position.column - 1 });
+            let result = slangd.gotoDefinition(model.uri.toString(), { line: position.lineNumber - 1, character: position.column - 1 });
             if (result == null) {
                 return null;
             }
@@ -565,7 +565,7 @@ export function initMonaco() {
                 triggerCharacter: context.hasOwnProperty("triggerCharacter") ? (context.triggerCharacter || "") : ""
             };
             let result = slangd.completion(
-                userCodeURI,
+                model.uri.toString(),
                 { line: position.lineNumber - 1, character: position.column - 1 },
                 lspContext
             );
@@ -608,7 +608,7 @@ export function initMonaco() {
             if (slangd == null) {
                 return null;
             }
-            let result = slangd.signatureHelp(userCodeURI, { line: position.lineNumber - 1, character: position.column - 1 });
+            let result = slangd.signatureHelp(model.uri.toString(), { line: position.lineNumber - 1, character: position.column - 1 });
             if (result == null) {
                 return null;
             }
@@ -669,7 +669,7 @@ export function initMonaco() {
             if (slangd == null) {
                 return null;
             }
-            let result = slangd.semanticTokens(userCodeURI);
+            let result = slangd.semanticTokens(model.uri.toString());
             if (result == null) {
                 return null;
             }


### PR DESCRIPTION
This PR adds a tab mechanism to the code editor on the top of the screen which allows the user to switch between a primary slang file and a "common.slang" file, where the latter can be imported into the former.

This link here should be able to demo: https://natevm.github.io/slang-playground/

<img width="997" alt="image" src="https://github.com/user-attachments/assets/a6e1f23d-354d-49be-9280-e51a72bd8757" />

<img width="997" alt="image" src="https://github.com/user-attachments/assets/d2d1c46c-0efa-4035-9901-cb91e21685c0" />


When the user writes `import common.slang` on the top of the main file, all functions defined in common are picked up in the main document. The editor also properly identifies functions and where they exist. (right click and go-to-definition doesn't work yet if the function is defined in another tab... I figure that could be another PR. On ToT it seems that "peak definition" isn't hooked up yet either. ). 

When the user shares a shader that they're working on, if that shader includes code in both tabs, then both will be combined into a common compressed json structure stored in the URL to share. 

This is meant to serve as a first step towards some more general multi-file solution. 