### PR TITLE
Add CALL_INDIRECT

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,4 @@ The files will then be available at `out/1/artifact/artifact.zip`.
 * Run `gh act -P ubuntu-latest=catthehacker/ubuntu:full-latest -j 'build' --artifact-server-path ./out`
 * This will create a file at `out/1/artifact/artifact.zip`
 * Extracting the zip file will provide a directory from which you can host the website with any web server
-    * As an example, you can use vscode's live server extension to host the website by opening `index.html`
-
+  * As an example, you can use vscode's live server extension to host the website by opening `index.html`

--- a/engine/playground-render-canvas/src/RenderCanvas.vue
+++ b/engine/playground-render-canvas/src/RenderCanvas.vue
@@ -962,7 +962,10 @@ function onRun(runCompiledCode: CompiledPlayground) {
 
                 // create a pipeline resource 'signature' based on the bindings found in the program.
                 pipeline.createPipelineLayout(pipelineBindings);
-                pipeline.createPipeline(module, entryPoint);
+                let pipelineCreationResult = await pipeline.createPipeline(module, entryPoint);
+                if (pipelineCreationResult.succ == false) {
+                    throw new Error(`Failed to create pipeline for entry point "${entryPoint}":\n${pipelineCreationResult.message}`);
+                }
                 pipeline.setThreadGroupSize(compiledCode.shader.threadGroupSizes[entryPoint]);
                 computePipelines.push(pipeline);
             }

--- a/engine/playground-render-canvas/src/RenderCanvas.vue
+++ b/engine/playground-render-canvas/src/RenderCanvas.vue
@@ -906,7 +906,7 @@ function getResourceMetadata(compiledCode: CompiledPlayground): { [k: string]: R
     for (const callCommand of compiledCode.callCommands) {
         if (callCommand.type === 'INDIRECT') {
             metadata[callCommand.bufferName].indirect = true;
-            metadata[callCommand.bufferName].excludeBinding.push("buffer");
+            metadata[callCommand.bufferName].excludeBinding.push(callCommand.fnName);
         }
     }
 
@@ -941,7 +941,7 @@ function onRun(runCompiledCode: CompiledPlayground) {
 
             const module = device.createShaderModule({ code: compiledCode.shader.code });
 
-            const resource_metadata = getResourceMetadata(compiledCode);
+            const resourceMetadata = getResourceMetadata(compiledCode);
 
             for (const callCommand of compiledCode.callCommands) {
                 const entryPoint = callCommand.fnName;
@@ -954,7 +954,7 @@ function onRun(runCompiledCode: CompiledPlayground) {
 
                 const pipelineBindings: Bindings = {};
                 for (const param in compiledCode.shader.layout) {
-                    if (resource_metadata[param]?.excludeBinding.includes(entryPoint)) {
+                    if (resourceMetadata[param]?.excludeBinding.includes(entryPoint)) {
                         continue;
                     }
                     pipelineBindings[param] = compiledCode.shader.layout[param];
@@ -970,7 +970,7 @@ function onRun(runCompiledCode: CompiledPlayground) {
             allocatedResources = await processResourceCommands(
                 compiledCode.shader.layout,
                 compiledCode.resourceCommands,
-                resource_metadata,
+                resourceMetadata,
                 compiledCode.uniformSize
             );
 

--- a/engine/shared/src/playgroundInterface.ts
+++ b/engine/shared/src/playgroundInterface.ts
@@ -211,6 +211,12 @@ export type CallCommand = {
 	fnName: string,
 	size: number[],
 	callOnce?: boolean,
+} | {
+	type: "INDIRECT",
+	fnName: string,
+	bufferName: string,
+	offset: number,
+	callOnce?: boolean,
 };
 
 export type PlaygroundRun = {

--- a/engine/slang-compilation-engine/media/playgroundDocumentation.md
+++ b/engine/slang-compilation-engine/media/playgroundDocumentation.md
@@ -85,6 +85,10 @@ Dispatch a compute pass using the resource size to determine the work-group size
 Dispatch a compute pass with the given grid of threads.
 The number of work-groups will be determined by dividing by the number of threads per work-group and rounding up.
 
+### `[playground::CALL_INDIRECT("BUFFER-NAME", 0)]`
+
+Dispatch a compute pass with an indirect command buffer and an offset in bytes.
+
 ### `[playground::CALL::ONCE]`
 
 Only dispatch the compute pass once at the start of rendering. Should be used in addition to another CALL command.

--- a/engine/slang-compilation-engine/src/playgroundCompiler.ts
+++ b/engine/slang-compilation-engine/src/playgroundCompiler.ts
@@ -384,6 +384,21 @@ function parseCallCommands(reflection: ReflectionJSON): Result<CallCommand[]> {
                     fnName,
                     size: attribute.arguments as number[]
                 };
+            } else if (attribute.name === "playground_CALL_INDIRECT") {
+                if (callCommand != null) {
+                    return {
+                        succ: false,
+                        message: `Multiple CALL commands found for ${fnName}`,
+                    };
+                }
+                const bufferName = attribute.arguments[0] as string;
+                const offset = attribute.arguments[1] as number;
+                callCommand = {
+                    type: "INDIRECT",
+                    fnName,
+                    bufferName,
+                    offset,
+                };
             } else if (attribute.name === "playground_CALL_ONCE") {
                 if (callOnce) {
                     return {

--- a/engine/slang-compilation-engine/src/slang/playground.slang
+++ b/engine/slang-compilation-engine/src/slang/playground.slang
@@ -195,6 +195,15 @@ public struct playground_CALL_SIZE_OFAttribute
     string resourceName;
 };
 
+// Dispatch a compute pass by indirect call: use a buffer name and an integer offset
+// (the buffer is expected to contain entrypoint indices or dispatch parameters).
+[__AttributeUsage(_AttributeTargets.Function)]
+public struct playground_CALL_INDIRECTAttribute
+{
+    string bufferName;
+    int offset;
+};
+
 // Only dispatch the compute pass once at the start of rendering.
 [__AttributeUsage(_AttributeTargets.Function)]
 public struct playground_CALL_ONCEAttribute

--- a/public/demos/painting.slang
+++ b/public/demos/painting.slang
@@ -39,7 +39,7 @@ void draw(uint2 dispatchThreadId: SV_DispatchThreadID)
     if (mousePosition.z >= 0)
         return;
 
-    let offset = float2(dispatchThreadId.xy) - float(MAX_BRUSH_SIZE) / 2;
+    let offset = float2(dispatchThreadId.xy) - brush_size;
     if (length(offset) > brush_size / 2)
         return;
 

--- a/public/demos/painting.slang
+++ b/public/demos/painting.slang
@@ -1,6 +1,7 @@
 import playground;
 
-const static int MAX_BRUSH_SIZE = 16;
+static const int MAX_BRUSH_SIZE = 64;
+static const uint THREAD_COUNT = 8;
 
 [playground::BLACK_SCREEN(1.0, 1.0)]
 RWTexture2D<float> tex_red;
@@ -9,7 +10,10 @@ RWTexture2D<float> tex_green;
 [playground::BLACK_SCREEN(1.0, 1.0)]
 RWTexture2D<float> tex_blue;
 
-[playground::SLIDER(10.0, 4.0, 16.0)]
+[playground::ZEROS(8)]
+RWStructuredBuffer<uint> indirectBuffer;
+
+[playground::SLIDER(10.0, 4.0, 64.0)]
 uniform float brush_size;
 [playground::COLOR_PICK(1.0, 0.0, 1.0)]
 uniform float3 color;
@@ -18,8 +22,18 @@ uniform float3 color;
 uniform float4 mousePosition;
 
 [shader("compute")]
-[numthreads(8, 8, 1)]
-[playground::CALL(MAX_BRUSH_SIZE, MAX_BRUSH_SIZE, 1)]
+[numthreads(1, 1, 1)]
+[playground::CALL(1, 1, 1)]
+void update(uint2 dispatchThreadId: SV_DispatchThreadID)
+{
+    indirectBuffer[0] = uint(2.0 * brush_size + THREAD_COUNT + 1.0) / THREAD_COUNT;
+    indirectBuffer[1] = uint(2.0 * brush_size + THREAD_COUNT + 1.0) / THREAD_COUNT;
+    indirectBuffer[2] = 1;
+}
+
+[shader("compute")]
+[numthreads(THREAD_COUNT, THREAD_COUNT, 1)]
+[playground::CALL_INDIRECT("indirectBuffer", 0)]
 void draw(uint2 dispatchThreadId: SV_DispatchThreadID)
 {
     if (mousePosition.z >= 0)

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -86,6 +86,8 @@ defineExpose({
         <h4 class="doc-header"><code>[playground::CALL(512, 512, 1)]</code></h4>
         Dispatch a compute pass with the given grid of threads.
         The number of work-groups will be determined by dividing by the number of threads per work-group and rounding up.
+        <h4 class="doc-header"><code>[playground::CALL_INDIRECT("BUFFER-NAME", 0)]</code></h4>
+        Dispatch a compute pass with an indirect command buffer and an offset in bytes.
         <h4 class="doc-header"><code>[playground::CALL::ONCE]</code></h4>
         Only dispatch the compute pass once at the start of rendering.
       <h4>Playground functions</h4>


### PR DESCRIPTION
closes #120
This PR enables indirect dispatch of entrypoints. It also updates the painting example to use this new feature to reduce unnecessary shader invocations.

Deploy: https://devon7925.github.io/slang-playground?demo=painting.slang