### PR TITLE
Add public keyword to lambda demo array for constructor synthesis

### DIFF
--- a/public/demos/lambda.slang
+++ b/public/demos/lambda.slang
@@ -7,7 +7,7 @@ import playground;
 
 public struct MyData
 {
-    int data[4];
+    public int data[4];
     MyData map(IFunc<int, int> f)
     {
         MyData result;


### PR DESCRIPTION
Fixes #166 

The lambda demo has an array `data` that it expects to be initialized with an implicitly defined constructor for the struct `MyData`, but Slang requires that the field be `public` in order for an public constructor to be synthesized. The array `data` does not have the `public` keyword, and in Slang 2025 its visibility is no longer `public` by default, and is instead `internal` by default, so no constructor is synthesized and the demo fails to compile now.

This PR just adds the `public` keyword to `data` to allow the expected constructor to be synthesized for `MyData`, allowing the demo to compile successfully.