### PR TITLE
Improve UniformController handling

### DIFF
--- a/engine/shared/src/index.ts
+++ b/engine/shared/src/index.ts
@@ -1,7 +1,12 @@
-import { UniformController } from './playgroundInterface';
+import { ScalarType, UniformController } from './playgroundInterface';
 
 export * from './playgroundInterface';
 
 export function isControllerRendered(controller: UniformController) {
     return controller.type == "SLIDER" || controller.type == "COLOR_PICK";
+}
+
+export function getScalarSize(scalarType: ScalarType): 8 | 16 | 32 | 64 {
+    let size = parseInt(scalarType.replace(/^[a-z]*/, ""));
+    return size as any;
 }

--- a/engine/shared/src/playgroundInterface.ts
+++ b/engine/shared/src/playgroundInterface.ts
@@ -113,10 +113,13 @@ export type UniformController = { buffer_offset: number } & ({
 	value: [number, number, number],
 } | {
 	type: "TIME",
+	scalarType: ScalarType,
 } | {
 	type: "FRAME_ID",
+	scalarType: ScalarType,
 } | {
 	type: "MOUSE_POSITION",
+	scalarType: ScalarType,
 } | {
 	type: "KEY",
 	key: string,
@@ -166,32 +169,6 @@ export type ParsedCommand = {
 	"type": "DATA",
 	"url": string,
 	"elementSize": number,
-} | {
-	"type": "SLIDER",
-	"default": number,
-	"min": number,
-	"max": number,
-	"elementSize": number,
-	"offset": number,
-} | {
-	"type": "COLOR_PICK",
-	"default": [number, number, number],
-	"elementSize": number,
-	"offset": number,
-} | {
-	"type": "TIME",
-	"offset": number,
-} | {
-	"type": "FRAME_ID",
-	"offset": number,
-} | {
-	"type": "MOUSE_POSITION",
-	"offset": number,
-} | {
-	"type": "KEY",
-	key: string,
-	offset: number,
-	scalarType: ScalarType,
 } | {
 	"type": "SAMPLER"
 };

--- a/engine/slang-compilation-engine/media/playgroundDocumentation.md
+++ b/engine/slang-compilation-engine/media/playgroundDocumentation.md
@@ -75,15 +75,15 @@ Initialize a `float` buffer with uniform random floats between 0 and 1.
 
 ### `[playground::TIME]`
 
-Gives a `float` uniform the current time in milliseconds.
+Gives a scalar uniform the current time in milliseconds.
 
 ### `[playground::FRAME_ID]`
 
-Gives a `float` uniform the current frame index (starting from 0).
+Gives a scalar uniform the current frame index (starting from 0).
 
 ### `[playground::MOUSE_POSITION]`
 
-Gives a `float4` uniform mouse data.
+Gives a 4 component vector uniform mouse data.
 
 * `xy`: mouse position (in pixels) during last button down
 * `abs(zw)`: mouse position during last button click

--- a/engine/slang-compilation-engine/src/compilationUtils.ts
+++ b/engine/slang-compilation-engine/src/compilationUtils.ts
@@ -1,4 +1,4 @@
-import { ScalarType, SlangFormat } from "slang-playground-shared";
+import { getScalarSize, ScalarType, SlangFormat } from "slang-playground-shared";
 
 export const ACCESS_MAP = {
     "readWrite": "read-write",
@@ -82,9 +82,4 @@ function getWebGPURepresentation(scalarType: ScalarType): ScalarRepresentation {
         type = "sint";
 
     return `${size}${type}` as any
-}
-
-function getScalarSize(scalarType: ScalarType): 8 | 16 | 32 | 64 {
-    let size = parseInt(scalarType.replace(/^[a-z]*/, ""));
-    return size as any;
 }

--- a/public/demos/painting.slang
+++ b/public/demos/painting.slang
@@ -16,7 +16,7 @@ uniform float brush_size;
 uniform float3 color;
 
 [playground::MOUSE_POSITION]
-uniform float4 mousePosition;
+uniform int4 mousePosition;
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
@@ -31,19 +31,19 @@ void update(uint2 dispatchThreadId: SV_DispatchThreadID)
 [shader("compute")]
 [numthreads(THREAD_COUNT, THREAD_COUNT, 1)]
 [playground::CALL_INDIRECT("indirectBuffer", 0)]
-void draw(uint2 dispatchThreadId: SV_DispatchThreadID)
+void draw(int2 dispatchThreadId: SV_DispatchThreadID)
 {
     if (mousePosition.z >= 0)
         return;
 
-    let offset = float2(dispatchThreadId.xy) - brush_size;
+    let offset = dispatchThreadId.xy - int2(brush_size);
     if (length(offset) > brush_size / 2)
         return;
 
     uint2 screenSize;
     tex.GetDimensions(screenSize.x, screenSize.y);
 
-    var mouse_pos = int2(0, screenSize.y) + int2(1, -1) * int2(mousePosition.xy + offset);
+    var mouse_pos = int2(0, screenSize.y) + int2(1, -1) * mousePosition.xy + offset;
     drawPixel(mouse_pos, (int2 screenSize) => {
         return float4(color, 1.0);
     });

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -66,11 +66,11 @@ defineExpose({
         <h4 class="doc-header"><code>[playground::RAND(1000)]</code></h4>
         Initialize a <code>float</code> buffer with uniform random floats between 0 and 1.
         <h4 class="doc-header"><code>[playground::TIME]</code></h4>
-        Gives a <code>float</code> uniform the current time in milliseconds.
+        Gives a scalar uniform the current time in milliseconds.
         <h4 class="doc-header"><code>[playground::FRAME_ID]</code></h4>
-        Gives a <code>float</code> uniform the current frame index (starting from 0).
+        Gives a scalar uniform the current frame index (starting from 0).
         <h4 class="doc-header"><code>[playground::MOUSE_POSITION]</code></h4>
-        Gives a <code>float4</code> uniform mouse data.
+        Gives a 4 component vector uniform mouse data.
         <ul>
           <li><code>xy</code>: mouse position (in pixels) during last button down.</br></li>
           <li><code>abs(zw)</code>: mouse position during last button click.</br></li>


### PR DESCRIPTION
This PR does the following:
* Remove uniform controllers from parsed commands
* Directly parse attributes to UniformControllers
* Assign uniform controller initial values using a shared function with the update code
* Support more scalar types for uniform controllers
* Related code quality improvements